### PR TITLE
fix: update CI workflow actions and Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,16 +96,14 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
-        cache: true
+        go-version: stable
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v4
+      uses: golangci/golangci-lint-action@v9
       with:
-        version: latest
-        args: --timeout=5m
+        version: v2.6


### PR DESCRIPTION
- Update actions/checkout from v4 to v5
- Update actions/setup-go from v5 to v6
- Update golangci-lint-action from v4 to v9
- Change Go version to 'stable' for automatic updates
- Update golangci-lint version to v2.6


## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [X] Test improvements
- [ ] Other (please describe): 
