### PR TITLE
feat: add 14 UI/UX improvements to interactive REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ An interactive agent built with the **official GitHub Copilot SDK** in Go that p
 - 📄 **Plain-Text Output**: Responses use emoji + uppercase headers (e.g. `🔵 STATUS:`, `⚠️ ISSUES:`) for clean, readable output without markdown tables or bold formatting
 - 🎯 **Type-Safe Tools**: Uses Copilot SDK's DefineTool for automatic schema generation
 - 💰 **Smart Cost Optimization**: Intelligent model selection based on task complexity (see [docs/MODEL_SELECTION.md](docs/MODEL_SELECTION.md))
-  - Uses `gpt-4o-mini` for simple queries (list, status, health checks)
-  - Automatically upgrades to `gpt-4o` for troubleshooting and complex operations
+  - Uses `gpt-4.1` for simple queries (list, status, health checks)
+  - Automatically upgrades to `claude-sonnet-4.6` for troubleshooting and complex operations
   - 50-70% cost reduction while maintaining quality for critical tasks
 - 🎭 **Specialist Agent Personas**: Four focused AI personas for advanced operations (see [docs/AGENTS.md](docs/AGENTS.md))
   - `--agent debugger` — root cause analysis, log correlation, pod failure diagnosis
@@ -313,8 +313,8 @@ KUBECONFIG=/path/to/kubeconfig ./bin/kopilot
 
 **Optional - Model Configuration:**
 
-- `KOPILOT_MODEL_COST_EFFECTIVE` - Override AI model for simple queries (default: `gpt-4o-mini`)
-- `KOPILOT_MODEL_PREMIUM` - Override AI model for complex operations (default: `gpt-4o`)
+- `KOPILOT_MODEL_COST_EFFECTIVE` - Override AI model for simple queries (default: `gpt-4.1`)
+- `KOPILOT_MODEL_PREMIUM` - Override AI model for complex operations (default: `claude-sonnet-4.6`)
 
 **Example:**
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -164,9 +164,9 @@ kopilot --help
 
 ## Model Selection and Agents
 
-All specialist agents (`debugger`, `security`, `optimizer`, `gitops`) always use the **premium model** (`gpt-4o` by default), regardless of how simple the query appears. This is because specialist reasoning benefits from higher model capacity — even a simple "list all pods" query issued through the Debugger agent may require deep context to give a meaningful diagnosis.
+All specialist agents (`debugger`, `security`, `optimizer`, `gitops`) always use the **premium model** (`claude-sonnet-4.6` by default), regardless of how simple the query appears. This is because specialist reasoning benefits from higher model capacity — even a simple "list all pods" query issued through the Debugger agent may require deep context to give a meaningful diagnosis.
 
-The `default` agent uses intelligent model selection: cost-effective (`gpt-4o-mini`) for simple queries and premium for troubleshooting and complex operations. See [MODEL_SELECTION.md](MODEL_SELECTION.md) for details.
+The `default` agent uses intelligent model selection: cost-effective (`gpt-4.1`) for simple queries and premium for troubleshooting and complex operations. See [MODEL_SELECTION.md](MODEL_SELECTION.md) for details.
 
 | Agent | Model strategy |
 | ------- | --------------- |

--- a/docs/MODEL_SELECTION.md
+++ b/docs/MODEL_SELECTION.md
@@ -6,7 +6,7 @@ Kopilot now uses intelligent model selection to optimize costs while maintaining
 
 ## Model Strategy
 
-### Cost-Effective Model: `gpt-4o-mini`
+### Cost-Effective Model: `gpt-4.1`
 
 **Use Cases:**
 
@@ -21,7 +21,7 @@ Kopilot now uses intelligent model selection to optimize costs while maintaining
 - Fast response times
 - Sufficient for straightforward tasks
 
-### Premium Model: `gpt-4o`
+### Premium Model: `claude-sonnet-4.6`
 
 **Use Cases:**
 
@@ -47,7 +47,7 @@ Kopilot now uses intelligent model selection to optimize costs while maintaining
 
 The model selection is dynamic and happens automatically:
 
-1. **Initial Session**: Starts with `gpt-4o-mini` for health checks
+1. **Initial Session**: Starts with `gpt-4.1` for health checks
 2. **Agent Check**: If a specialist agent is active (`debugger`, `security`, `optimizer`, `gitops`), always use the premium model regardless of query text
 3. **Query Analysis**: For the `default` agent, each user query is analyzed for complexity
 4. **Session Recreation**: When a different model is needed, the session is recreated with the optimal model
@@ -118,8 +118,8 @@ By using this strategy:
 Model switches are logged:
 
 ```text
-2024/01/15 10:30:45 Switching from gpt-4o-mini to gpt-4o for query complexity
-2024/01/15 10:30:45 Session created with model: gpt-4o
+2024/01/15 10:30:45 Switching from gpt-4.1 to claude-sonnet-4.6 for query complexity
+2024/01/15 10:30:45 Session created with model: claude-sonnet-4.6
 ```
 
 ## Future Enhancements

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This directory contains technical documentation for developers and contributors.
 - **[AGENTS.md](AGENTS.md)** - Specialist agent personas (Debugger, Security, Optimizer, GitOps) — how to use them and what each one does
 - **[EXECUTION_MODES.md](EXECUTION_MODES.md)** - Execution mode system (read-only vs interactive) for safe kubectl operations
 - **[TESTING.md](TESTING.md)** - Comprehensive testing guide including test structure, coverage reports, and how to run tests
-- **[MODEL_SELECTION.md](MODEL_SELECTION.md)** - Intelligent model selection strategy for cost optimization (gpt-4o-mini vs gpt-4o)
+- **[MODEL_SELECTION.md](MODEL_SELECTION.md)** - Intelligent model selection strategy for cost optimization (gpt-4.1 vs claude-sonnet-4.6)
 - **[PERFORMANCE.md](PERFORMANCE.md)** - Performance optimization details, including parallel cluster checking implementation
 - **[INTERACTIVE_FEATURES.md](INTERACTIVE_FEATURES.md)** - Interactive and proactive features implementation, including kubectl command execution
 - **[VERSION_MANAGEMENT.md](VERSION_MANAGEMENT.md)** - Versioning strategy and release workflow using Git tags

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/chzyer/readline v1.5.1
-	github.com/github/copilot-sdk/go v0.2.0
+	github.com/github/copilot-sdk/go v0.2.2
 	github.com/klauspost/compress v1.18.5
 	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/github/copilot-sdk/go v0.2.0 h1:RnrIIirmtp4wGgqSQFJ2k9phbeveIxOtYZqDogoNEa0=
-github.com/github/copilot-sdk/go v0.2.0/go.mod h1:uGWkjVYcp2DV9DgtqYihh5tEoJjNqxIFaUNnrwY4FxM=
+github.com/github/copilot-sdk/go v0.2.2 h1:QPgh0kGu4WYZUVBXjnKr3atR1rMTet7xuPUXkdZQumI=
+github.com/github/copilot-sdk/go v0.2.2/go.mod h1:uGWkjVYcp2DV9DgtqYihh5tEoJjNqxIFaUNnrwY4FxM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -416,6 +416,9 @@ const (
 
 	// fmtErrorBullet is the format string for inline error messages
 	fmtErrorBullet = "  %s●%s Error: %v\n"
+
+	// subCmdList is the "list" sub-command token used by /agent, /mcp, and /context.
+	subCmdList = "list"
 )
 
 const (
@@ -1362,7 +1365,7 @@ func handleAgentCommand(input string, state *agentState) (isCommand bool, newAge
 	parts := strings.Fields(trimmed)
 
 	// "/agent" or "/agent list" → show status and roster
-	if len(parts) == 1 || (len(parts) == 2 && strings.ToLower(parts[1]) == "list") {
+	if len(parts) == 1 || (len(parts) == 2 && strings.ToLower(parts[1]) == subCmdList) {
 		printAgentList(state)
 		return true, state.selectedAgent, nil
 	}
@@ -1496,7 +1499,7 @@ func dispatchMCPCommand(deps *loopDeps, input string, ts *turnState) (bool, erro
 	}
 
 	parts := strings.Fields(trimmed)
-	if len(parts) == 1 || (len(parts) == 2 && strings.ToLower(parts[1]) == "list") {
+	if len(parts) == 1 || (len(parts) == 2 && strings.ToLower(parts[1]) == subCmdList) {
 		printMCPList(deps.state.mcpConfigPath)
 		return true, nil
 	}
@@ -1743,7 +1746,12 @@ func extractAttachments(input string) (string, []copilot.Attachment) {
 			kept = append(kept, w)
 			continue
 		}
-		if _, err := os.Stat(abs); err != nil {
+		fi, statErr := os.Stat(abs)
+		if statErr != nil {
+			kept = append(kept, w)
+			continue
+		}
+		if !fi.Mode().IsRegular() {
 			kept = append(kept, w)
 			continue
 		}
@@ -1786,7 +1794,13 @@ func handleShellPassthrough(cmdStr string) {
 		return
 	}
 	fmt.Printf("  %s$ %s%s\n", colorDim, cmdStr, colorReset)
-	cmd := exec.Command("sh", "-c", cmdStr) // #nosec G204
+
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd.exe", "/C", cmdStr) // #nosec G204
+	} else {
+		cmd = exec.Command("sh", "-c", cmdStr) // #nosec G204
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
@@ -1942,7 +1956,7 @@ func handleModelCommand(deps *loopDeps, input string, ts *turnState) (bool, erro
 // handleContextCommand processes /context list and /context use <name> commands.
 func handleContextCommand(deps *loopDeps, input string) (bool, error) {
 	parts := strings.Fields(input)
-	if len(parts) == 1 || (len(parts) == 2 && strings.ToLower(parts[1]) == "list") {
+	if len(parts) == 1 || (len(parts) == 2 && strings.ToLower(parts[1]) == subCmdList) {
 		clusters := deps.k8sProvider.GetClusters()
 		current := deps.k8sProvider.GetCurrentContext()
 		fmt.Println()
@@ -1975,6 +1989,56 @@ func handleContextCommand(deps *loopDeps, input string) (bool, error) {
 	return true, nil
 }
 
+// handleLast prints the last assistant response to stdout.
+func handleLast(state *agentState) (bool, error) {
+	if state.lastResponseText == "" {
+		fmt.Printf("  %s●%s No previous response to show\n", colorDim, colorReset)
+	} else {
+		fmt.Println()
+		fmt.Println(state.lastResponseText)
+	}
+	return true, nil
+}
+
+// handleCopy copies the last assistant response to the system clipboard.
+func handleCopy(state *agentState) (bool, error) {
+	if state.lastResponseText == "" {
+		fmt.Printf("  %s●%s Nothing to copy yet\n", colorDim, colorReset)
+		return true, nil
+	}
+	if err := copyToClipboard(state.lastResponseText); err != nil {
+		fmt.Printf(fmtErrorBullet, colorRed, colorReset, err)
+		return true, nil
+	}
+	fmt.Printf("  %s●%s Copied to clipboard (%d characters)\n",
+		colorGreen, colorReset, len(state.lastResponseText))
+	return true, nil
+}
+
+// handleStreamer toggles or sets streamer mode (on/off).
+func handleStreamer(state *agentState, input string) (bool, error) {
+	parts := strings.Fields(input)
+	if len(parts) >= 2 {
+		switch strings.ToLower(parts[1]) {
+		case "on":
+			state.streamerMode = true
+		case "off":
+			state.streamerMode = false
+		default:
+			fmt.Printf("  %s●%s Usage: /streamer [on|off]\n", colorRed, colorReset)
+			return true, nil
+		}
+	} else {
+		state.streamerMode = !state.streamerMode
+	}
+	if state.streamerMode {
+		fmt.Printf("  %s●%s Streamer mode on — quota info hidden\n", colorGreen, colorReset)
+	} else {
+		fmt.Printf("  %s●%s Streamer mode off\n", colorGreen, colorReset)
+	}
+	return true, nil
+}
+
 // dispatchUXCommand handles the new UX-related slash commands introduced in this release.
 // Returns (handled bool, err error).
 func dispatchUXCommand(deps *loopDeps, input string, ts *turnState) (bool, error) {
@@ -1988,46 +2052,11 @@ func dispatchUXCommand(deps *loopDeps, input string, ts *turnState) (bool, error
 	case lower == "/compact":
 		return true, handleCompact(deps, ts)
 	case lower == "/last":
-		if deps.state.lastResponseText == "" {
-			fmt.Printf("  %s●%s No previous response to show\n", colorDim, colorReset)
-		} else {
-			fmt.Println()
-			fmt.Println(deps.state.lastResponseText)
-		}
-		return true, nil
+		return handleLast(deps.state)
 	case lower == "/copy":
-		if deps.state.lastResponseText == "" {
-			fmt.Printf("  %s●%s Nothing to copy yet\n", colorDim, colorReset)
-			return true, nil
-		}
-		if err := copyToClipboard(deps.state.lastResponseText); err != nil {
-			fmt.Printf(fmtErrorBullet, colorRed, colorReset, err)
-			return true, nil
-		}
-		fmt.Printf("  %s●%s Copied to clipboard (%d characters)\n",
-			colorGreen, colorReset, len(deps.state.lastResponseText))
-		return true, nil
+		return handleCopy(deps.state)
 	case lower == "/streamer" || strings.HasPrefix(lower, "/streamer "):
-		parts := strings.Fields(input)
-		if len(parts) >= 2 {
-			switch strings.ToLower(parts[1]) {
-			case "on":
-				deps.state.streamerMode = true
-			case "off":
-				deps.state.streamerMode = false
-			default:
-				fmt.Printf("  %s●%s Usage: /streamer [on|off]\n", colorRed, colorReset)
-				return true, nil
-			}
-		} else {
-			deps.state.streamerMode = !deps.state.streamerMode
-		}
-		if deps.state.streamerMode {
-			fmt.Printf("  %s●%s Streamer mode on — quota info hidden\n", colorGreen, colorReset)
-		} else {
-			fmt.Printf("  %s●%s Streamer mode off\n", colorGreen, colorReset)
-		}
-		return true, nil
+		return handleStreamer(deps.state, input)
 	case strings.HasPrefix(lower, "/model"):
 		return handleModelCommand(deps, input, ts)
 	case strings.HasPrefix(lower, "/context"):

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -474,7 +474,7 @@ type agentState struct {
 	abortMu          sync.Mutex
 	// responseMu guards lastResponseText which is written from the event-handler
 	// goroutine and read from the main REPL loop.
-	responseMu       sync.RWMutex
+	responseMu sync.RWMutex
 	// UX enhancements
 	forcedModel        string    // /model override; empty = auto-routing
 	streamerMode       bool      // /streamer: hide quota badge in prompt
@@ -1801,14 +1801,22 @@ func copyToClipboard(text string) error {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
-		cmd = exec.Command("pbcopy") // #nosec G204
+		pbcopyPath, err := exec.LookPath("pbcopy")
+		if err != nil {
+			return fmt.Errorf("pbcopy not found: %w", err)
+		}
+		cmd = exec.Command(pbcopyPath) // #nosec G204
 	case "windows":
-		cmd = exec.Command("clip") // #nosec G204
+		clipPath, err := exec.LookPath("clip")
+		if err != nil {
+			return fmt.Errorf("clip not found: %w", err)
+		}
+		cmd = exec.Command(clipPath) // #nosec G204
 	default:
-		if _, err := exec.LookPath("xclip"); err == nil {
-			cmd = exec.Command("xclip", "-sel", "clip") // #nosec G204
-		} else if _, err := exec.LookPath("xsel"); err == nil {
-			cmd = exec.Command("xsel", "--clipboard", "--input") // #nosec G204
+		if xclipPath, err := exec.LookPath("xclip"); err == nil {
+			cmd = exec.Command(xclipPath, "-sel", "clip") // #nosec G204
+		} else if xselPath, err := exec.LookPath("xsel"); err == nil {
+			cmd = exec.Command(xselPath, "--clipboard", "--input") // #nosec G204
 		} else {
 			return fmt.Errorf("no clipboard utility found (install xclip or xsel)")
 		}
@@ -1827,9 +1835,14 @@ func handleShellPassthrough(cmdStr string) {
 
 	var cmd *exec.Cmd
 	if runtime.GOOS == "windows" {
-		cmd = exec.Command("cmd.exe", "/C", cmdStr) // #nosec G204
+		cmdExePath, err := exec.LookPath("cmd.exe")
+		if err != nil {
+			fmt.Printf(fmtErrorBullet, colorRed, colorReset, err)
+			return
+		}
+		cmd = exec.Command(cmdExePath, "/C", cmdStr) // #nosec G204
 	} else {
-		cmd = exec.Command("sh", "-c", cmdStr) // #nosec G204
+		cmd = exec.Command("/bin/sh", "-c", cmdStr) // #nosec G204
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -472,6 +472,9 @@ type agentState struct {
 	// sending a user prompt and cleared when the turn ends.
 	abortCurrentTurn func()
 	abortMu          sync.Mutex
+	// responseMu guards lastResponseText which is written from the event-handler
+	// goroutine and read from the main REPL loop.
+	responseMu       sync.RWMutex
 	// UX enhancements
 	forcedModel        string    // /model override; empty = auto-routing
 	streamerMode       bool      // /streamer: hide quota badge in prompt
@@ -480,7 +483,7 @@ type agentState struct {
 	turnsMiniCount     int       // turns sent to cost-effective model
 	turnsGPT4Count     int       // turns sent to premium model
 	premiumUsedAtStart float64   // quotaUsed at session start (delta for /usage)
-	lastResponseText   string    // for /copy, /last, and truncation
+	lastResponseText   string    // for /copy, /last, and truncation; guarded by responseMu
 }
 
 // setAbortCurrentTurn installs (or clears) the active-turn abort callback.
@@ -498,6 +501,20 @@ func (s *agentState) abortTurnIfActive() {
 	if fn != nil {
 		fn()
 	}
+}
+
+// setLastResponse stores the last assistant response text in a thread-safe manner.
+func (s *agentState) setLastResponse(text string) {
+	s.responseMu.Lock()
+	defer s.responseMu.Unlock()
+	s.lastResponseText = text
+}
+
+// getLastResponse returns the last assistant response text in a thread-safe manner.
+func (s *agentState) getLastResponse() string {
+	s.responseMu.RLock()
+	defer s.responseMu.RUnlock()
+	return s.lastResponseText
 }
 
 // loopDeps groups the immutable runtime dependencies shared across the interactive session loop.
@@ -606,7 +623,7 @@ func onMessageEvent(event copilot.SessionEvent, state *agentState) {
 		fmt.Println()
 		spinnerPaused.Store(0)
 		if event.Data.Content != nil {
-			state.lastResponseText = *event.Data.Content
+			state.setLastResponse(*event.Data.Content)
 		}
 		return
 	}
@@ -614,7 +631,7 @@ func onMessageEvent(event copilot.SessionEvent, state *agentState) {
 		return
 	}
 	content := *event.Data.Content
-	state.lastResponseText = content
+	state.setLastResponse(content)
 	fmt.Println()
 	lines := strings.Split(content, "\n")
 	if len(lines) > maxDisplayLines {
@@ -1163,16 +1180,21 @@ func rlPromptString(state *agentState) string {
 }
 
 // newReadlineInstance creates a readline instance with persistent cross-session history.
+// If historyFilePath() returns an empty string (e.g., no home dir), history persistence
+// is simply disabled rather than failing to start the REPL.
 func newReadlineInstance() (*readline.Instance, error) {
-	return readline.NewEx(&readline.Config{
-		HistoryFile:            historyFilePath(),
+	cfg := &readline.Config{
 		HistoryLimit:           500,
 		InterruptPrompt:        "^C",
 		EOFPrompt:              "exit",
 		HistorySearchFold:      true,
 		DisableAutoSaveHistory: false,
 		Painter:                &cyanPainter{},
-	})
+	}
+	if hp := historyFilePath(); hp != "" {
+		cfg.HistoryFile = hp
+	}
+	return readline.NewEx(cfg)
 }
 
 // readUserInput reads and trims user input via the readline instance.
@@ -1902,7 +1924,7 @@ func handleCompact(deps *loopDeps, ts *turnState) error {
 		return fmt.Errorf("failed to send compact prompt: %w", err)
 	}
 	waitForIdleWithSpinner(deps.isIdle)
-	summary := deps.state.lastResponseText
+	summary := deps.state.getLastResponse()
 	prevTurns := deps.state.turnCount
 	newSession, err := switchToModel(deps, ts.session, ts.model)
 	if err != nil {
@@ -1999,27 +2021,29 @@ func handleContextCommand(deps *loopDeps, input string) (bool, error) {
 
 // handleLast prints the last assistant response to stdout.
 func handleLast(state *agentState) (bool, error) {
-	if state.lastResponseText == "" {
+	last := state.getLastResponse()
+	if last == "" {
 		fmt.Printf("  %s●%s No previous response to show\n", colorDim, colorReset)
 	} else {
 		fmt.Println()
-		fmt.Println(state.lastResponseText)
+		fmt.Println(last)
 	}
 	return true, nil
 }
 
 // handleCopy copies the last assistant response to the system clipboard.
 func handleCopy(state *agentState) (bool, error) {
-	if state.lastResponseText == "" {
+	last := state.getLastResponse()
+	if last == "" {
 		fmt.Printf("  %s●%s Nothing to copy yet\n", colorDim, colorReset)
 		return true, nil
 	}
-	if err := copyToClipboard(state.lastResponseText); err != nil {
+	if err := copyToClipboard(last); err != nil {
 		fmt.Printf(fmtErrorBullet, colorRed, colorReset, err)
 		return true, nil
 	}
 	fmt.Printf("  %s●%s Copied to clipboard (%d characters)\n",
-		colorGreen, colorReset, len(state.lastResponseText))
+		colorGreen, colorReset, len(last))
 	return true, nil
 }
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -5,11 +5,15 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"math/rand/v2"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -465,6 +469,15 @@ type agentState struct {
 	// sending a user prompt and cleared when the turn ends.
 	abortCurrentTurn func()
 	abortMu          sync.Mutex
+	// UX enhancements
+	forcedModel        string    // /model override; empty = auto-routing
+	streamerMode       bool      // /streamer: hide quota badge in prompt
+	sessionStart       time.Time // for /usage statistics
+	turnCount          int       // total turns this session
+	turnsMiniCount     int       // turns sent to cost-effective model
+	turnsGPT4Count     int       // turns sent to premium model
+	premiumUsedAtStart float64   // quotaUsed at session start (delta for /usage)
+	lastResponseText   string    // for /copy, /last, and truncation
 }
 
 // setAbortCurrentTurn installs (or clears) the active-turn abort callback.
@@ -578,11 +591,38 @@ Cluster targeting:
 Be helpful, clear, and conversational.`
 }
 
+// maxDisplayLines is the threshold above which long responses are truncated in the terminal.
+const maxDisplayLines = 30
+
 // onMessageEvent handles the final complete assistant message.
-func onMessageEvent(event copilot.SessionEvent) {
-	if event.Data.Content != nil && *event.Data.Content != "" {
+// When streaming was active the content was already printed incrementally;
+// this function only stores it and closes the streaming state in that case.
+func onMessageEvent(event copilot.SessionEvent, state *agentState) {
+	if streamingActive.Swap(false) {
+		// Content was already streamed incrementally — just finalise
 		fmt.Println()
-		fmt.Println(*event.Data.Content)
+		spinnerPaused.Store(0)
+		if event.Data.Content != nil {
+			state.lastResponseText = *event.Data.Content
+		}
+		return
+	}
+	if event.Data.Content == nil || *event.Data.Content == "" {
+		return
+	}
+	content := *event.Data.Content
+	state.lastResponseText = content
+	fmt.Println()
+	lines := strings.Split(content, "\n")
+	if len(lines) > maxDisplayLines {
+		for _, line := range lines[:maxDisplayLines] {
+			fmt.Println(line)
+		}
+		remaining := len(lines) - maxDisplayLines
+		fmt.Printf("  %s... (%d more lines) — type /last to see full output%s\n",
+			colorDim, remaining, colorReset)
+	} else {
+		fmt.Println(content)
 	}
 }
 
@@ -627,7 +667,9 @@ func setupSessionEventHandler(session *copilot.Session, isIdlePtr *bool, state *
 	session.On(func(event copilot.SessionEvent) {
 		switch event.Type {
 		case "assistant.message":
-			onMessageEvent(event)
+			onMessageEvent(event, state)
+		case "assistant.message.delta":
+			onDeltaEvent(event)
 		case "session.error":
 			onSessionErrorEvent(event)
 		case "session.idle":
@@ -688,6 +730,7 @@ func Run(k8sProvider *k8s.Provider, mode ExecutionMode, outputFormat OutputForma
 		quotaPercentage: -1,
 		selectedAgent:   agentType,
 		mcpConfigPath:   mcpConfigPath,
+		sessionStart:    time.Now(),
 	}
 
 	// Create a cancellable context for the entire agent lifecycle
@@ -815,7 +858,7 @@ func printBannerExamples(agentType AgentType) {
 	}
 	fmt.Println()
 	fmt.Printf("  %sType your request to get started. Enter 'exit' to quit.%s\n", colorDim, colorReset)
-	fmt.Printf("  %sHint: /help to see all commands or /agent list to see specialist agents.%s\n", colorDim, colorReset)
+	fmt.Printf("  %sHint: /help for all commands • @<file> to attach • !<cmd> to run shell • Ctrl+C to cancel%s\n", colorDim, colorReset)
 	fmt.Println()
 }
 
@@ -923,7 +966,7 @@ func createSessionWithModel(ctx context.Context, client *copilot.Client, k8sProv
 
 	session, err := client.CreateSession(ctx, &copilot.SessionConfig{
 		Model:               model,
-		Streaming:           false,
+		Streaming:           true,
 		Tools:               tools,
 		CustomAgents:        buildCustomAgents(),
 		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
@@ -945,7 +988,11 @@ func createSessionWithModel(ctx context.Context, client *copilot.Client, k8sProv
 // selectModelForQuery determines the best model based on query complexity, intent, and active agent.
 // Specialist agents always use the premium model — their reasoning tasks benefit from higher
 // model capacity regardless of how simple the query text appears.
-func selectModelForQuery(query string, agentType AgentType) string {
+// When forcedModel is non-empty it overrides all automatic selection logic.
+func selectModelForQuery(query string, agentType AgentType, forcedModel string) string {
+	if forcedModel != "" {
+		return forcedModel
+	}
 	// Specialist agents always warrant the premium model
 	if def, ok := agentDefinitions[agentType]; ok && def.preferPremium {
 		return modelPremium
@@ -999,6 +1046,9 @@ var spinnerFrames = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "�
 
 // spinnerPaused is set to 1 while a tool needs exclusive terminal access (e.g. interactive confirmation prompt).
 var spinnerPaused atomic.Int32
+
+// streamingActive is true while an assistant.message.delta stream is in progress.
+var streamingActive atomic.Bool
 
 // pauseSpinner suppresses the spinner and clears any in-progress spinner line.
 // The caller must call the returned resume function when done.
@@ -1090,7 +1140,7 @@ func (p *cyanPainter) Paint(line []rune, _ int) []rune {
 // Input text colouring is handled by cyanPainter, not the prompt string.
 func rlPromptString(state *agentState) string {
 	wrap := func(seq string) string { return "\x01" + seq + "\x02" }
-	if isJSONOutput(state.outputFormat) || state.quotaUnlimited || state.quotaPercentage < 0 {
+	if isJSONOutput(state.outputFormat) || state.quotaUnlimited || state.quotaPercentage < 0 || state.streamerMode {
 		return "❯ "
 	}
 	pct := state.quotaPercentage
@@ -1109,9 +1159,10 @@ func rlPromptString(state *agentState) string {
 	return wrap(col) + indicator + wrap(colorReset) + " ❯ "
 }
 
-// newReadlineInstance creates a readline instance with in-session history.
+// newReadlineInstance creates a readline instance with persistent cross-session history.
 func newReadlineInstance() (*readline.Instance, error) {
 	return readline.NewEx(&readline.Config{
+		HistoryFile:            historyFilePath(),
 		HistoryLimit:           500,
 		InterruptPrompt:        "^C",
 		EOFPrompt:              "exit",
@@ -1154,8 +1205,12 @@ func isUnknownSlashCommand(input string) bool {
 		return false
 	}
 	lower := strings.TrimSpace(strings.ToLower(input))
-	// Known prefixes — keep in sync with handleModeSwitch, handleAgentCommand, handleMCPCommand.
-	known := []string{"/help", "/mode", "/status", "/readonly", "/interactive", "/agent", "/mcp"}
+	// Known prefixes — keep in sync with handleModeSwitch, handleAgentCommand, handleMCPCommand, dispatchUXCommand.
+	known := []string{
+		"/help", "/mode", "/status", "/readonly", "/interactive", "/agent", "/mcp",
+		"/clear", "/new", "/usage", "/compact", "/last", "/copy",
+		"/model", "/streamer", "/context",
+	}
 	for _, prefix := range known {
 		if lower == prefix || strings.HasPrefix(lower, prefix+" ") {
 			return false
@@ -1171,23 +1226,44 @@ func printHelpMessage(state *agentState) {
 	fmt.Printf("  %s━━ Kopilot Commands ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━%s\n", colorCyan, colorReset)
 	fmt.Println()
 	fmt.Printf("  %sSession%s\n", colorDim, colorReset)
-	fmt.Printf("    %s/help%s             show this help message\n", colorCyan, colorReset)
-	fmt.Printf("    %sexit%s, %squit%s        exit Kopilot\n", colorCyan, colorReset, colorCyan, colorReset)
+	fmt.Printf("    %s/help%s              show this help message\n", colorCyan, colorReset)
+	fmt.Printf("    %s/clear%s, %s/new%s        start a fresh conversation\n", colorCyan, colorReset, colorCyan, colorReset)
+	fmt.Printf("    %s/usage%s             show session duration, turns, and quota\n", colorCyan, colorReset)
+	fmt.Printf("    %s/compact%s           summarize history to save context window\n", colorCyan, colorReset)
+	fmt.Printf("    %s/last%s              re-show the last full response\n", colorCyan, colorReset)
+	fmt.Printf("    %s/copy%s              copy the last response to clipboard\n", colorCyan, colorReset)
+	fmt.Printf("    %sexit%s, %squit%s         exit Kopilot\n", colorCyan, colorReset, colorCyan, colorReset)
 	fmt.Println()
 	fmt.Printf("  %sExecution Mode%s\n", colorDim, colorReset)
-	fmt.Printf("    %s/mode%s, %s/status%s       show current execution mode\n", colorCyan, colorReset, colorCyan, colorReset)
-	fmt.Printf("    %s/readonly%s [on]       switch to 🔒 read-only mode (blocks write operations)\n", colorCyan, colorReset)
-	fmt.Printf("    %s/interactive%s [on]    switch to 🔓 interactive mode (prompts before writes)\n", colorCyan, colorReset)
+	fmt.Printf("    %s/mode%s, %s/status%s        show current execution mode\n", colorCyan, colorReset, colorCyan, colorReset)
+	fmt.Printf("    %s/readonly%s [on]        switch to 🔒 read-only mode (blocks write operations)\n", colorCyan, colorReset)
+	fmt.Printf("    %s/interactive%s [on]     switch to 🔓 interactive mode (prompts before writes)\n", colorCyan, colorReset)
+	fmt.Println()
+	fmt.Printf("  %sModel%s\n", colorDim, colorReset)
+	fmt.Printf("    %s/model%s              show current model / routing mode\n", colorCyan, colorReset)
+	fmt.Printf("    %s/model <name>%s       force a specific model for this session\n", colorCyan, colorReset)
+	fmt.Printf("    %s/model reset%s        re-enable automatic model routing\n", colorCyan, colorReset)
+	fmt.Printf("    %s/streamer%s [on|off]  hide quota badge (useful for screen-sharing)\n", colorCyan, colorReset)
+	fmt.Println()
+	fmt.Printf("  %sKubernetes Context%s\n", colorDim, colorReset)
+	fmt.Printf("    %s/context list%s         list all kubeconfig contexts\n", colorCyan, colorReset)
+	fmt.Printf("    %s/context use <name>%s   switch active context\n", colorCyan, colorReset)
 	fmt.Println()
 	fmt.Printf("  %sSpecialist Agents%s\n", colorDim, colorReset)
-	fmt.Printf("    %s/agent%s             show active agent and available roster\n", colorCyan, colorReset)
-	fmt.Printf("    %s/agent list%s        same as /agent\n", colorCyan, colorReset)
-	fmt.Printf("    %s/agent <name>%s      switch agent  [ %s ]\n", colorCyan, colorReset, agentNames)
+	fmt.Printf("    %s/agent%s              show active agent and available roster\n", colorCyan, colorReset)
+	fmt.Printf("    %s/agent list%s         same as /agent\n", colorCyan, colorReset)
+	fmt.Printf("    %s/agent <name>%s       switch agent  [ %s ]\n", colorCyan, colorReset, agentNames)
 	fmt.Println()
 	fmt.Printf("  %sMCP Servers%s\n", colorDim, colorReset)
 	fmt.Printf("    %s/mcp list%s              list configured MCP servers\n", colorCyan, colorReset)
 	fmt.Printf("    %s/mcp add <name> <url>%s  add or update an MCP server\n", colorCyan, colorReset)
 	fmt.Printf("    %s/mcp delete <name>%s     remove an MCP server\n", colorCyan, colorReset)
+	fmt.Println()
+	fmt.Printf("  %sShortcuts%s\n", colorDim, colorReset)
+	fmt.Printf("    %s@<file>%s                attach a file to the next message\n", colorCyan, colorReset)
+	fmt.Printf("    %s!<command>%s             run a shell command without AI\n", colorCyan, colorReset)
+	fmt.Printf("    %sCtrl+C%s                cancel current input / abort AI response\n", colorCyan, colorReset)
+	fmt.Printf("    %sCtrl+D%s                exit\n", colorCyan, colorReset)
 	fmt.Println()
 	fmt.Printf("  %sCurrent mode: %s  |  Active agent: %s%s\n", colorDim, state.mode, state.selectedAgent, colorReset)
 	fmt.Println()
@@ -1354,6 +1430,12 @@ func processTurn(deps *loopDeps, rl *readline.Instance, ts *turnState) (exit boo
 		return false, nil
 	}
 
+	// Shell passthrough: lines starting with ! bypass the AI entirely
+	if strings.HasPrefix(input, "!") {
+		handleShellPassthrough(strings.TrimPrefix(input, "!"))
+		return false, nil
+	}
+
 	if isExitCommand(input) {
 		fmt.Println("")
 		return true, nil
@@ -1364,6 +1446,10 @@ func processTurn(deps *loopDeps, rl *readline.Instance, ts *turnState) (exit boo
 
 	if handleModeSwitch(input, deps.state) {
 		return false, nil
+	}
+
+	if handled, err := dispatchUXCommand(deps, input, ts); handled {
+		return false, err
 	}
 
 	if handled, err := dispatchAgentCommand(deps, input, ts); handled {
@@ -1547,7 +1633,26 @@ func printLongRunningWarning(agentType AgentType) {
 
 // sendToModel selects the best model for the query and sends it, updating ts as needed.
 func sendToModel(deps *loopDeps, ts *turnState, input string) error {
-	if optimalModel := selectModelForQuery(input, deps.state.selectedAgent); optimalModel != ts.model {
+	// @ file attachment injection
+	prompt, attachments := extractAttachments(input)
+	if len(attachments) > 0 && !isJSONOutput(deps.state.outputFormat) {
+		for _, a := range attachments {
+			if a.Path != nil {
+				if fi, err := os.Stat(*a.Path); err == nil {
+					dname := ""
+					if a.DisplayName != nil {
+						dname = *a.DisplayName
+					}
+					fmt.Printf("  %s📎 Attached: %s (%s)%s\n", colorCyan, dname, formatBytes(fi.Size()), colorReset)
+				}
+			}
+		}
+	}
+	if prompt == "" {
+		prompt = input // fallback if all tokens were attachments
+	}
+
+	if optimalModel := selectModelForQuery(prompt, deps.state.selectedAgent, deps.state.forcedModel); optimalModel != ts.model {
 		newSession, err := switchToModel(deps, ts.session, optimalModel)
 		if err != nil {
 			return err
@@ -1555,7 +1660,7 @@ func sendToModel(deps *loopDeps, ts *turnState, input string) error {
 		ts.session = newSession
 		ts.model = optimalModel
 	}
-	if !isJSONOutput(deps.state.outputFormat) && isLongRunningQuery(input, deps.state.selectedAgent) {
+	if !isJSONOutput(deps.state.outputFormat) && isLongRunningQuery(prompt, deps.state.selectedAgent) {
 		printLongRunningWarning(deps.state.selectedAgent)
 	}
 	*deps.isIdle = false
@@ -1564,12 +1669,371 @@ func sendToModel(deps *loopDeps, ts *turnState, input string) error {
 			log.Printf("Warning: failed to abort current turn: %v", abortErr)
 		}
 	})
-	_, err := ts.session.Send(deps.ctx, copilot.MessageOptions{Prompt: input})
+	msgOpts := copilot.MessageOptions{
+		Prompt:      prompt,
+		Attachments: attachments,
+	}
+	_, err := ts.session.Send(deps.ctx, msgOpts)
 	if err != nil {
 		deps.state.setAbortCurrentTurn(nil)
 		return fmt.Errorf("failed to send message: %w", err)
 	}
+	// Track per-turn model usage
+	deps.state.turnCount++
+	if ts.model == modelCostEffective {
+		deps.state.turnsMiniCount++
+	} else {
+		deps.state.turnsGPT4Count++
+	}
 	return nil
+}
+
+// historyFilePath returns the path to the persistent readline history file.
+// Creates ~/.kopilot/ if it does not exist.
+func historyFilePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	dir := filepath.Join(home, ".kopilot")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "history")
+}
+
+// formatBytes formats a byte count as a human-readable string.
+func formatBytes(n int64) string {
+	const kb = 1024
+	const mb = kb * 1024
+	switch {
+	case n >= mb:
+		return fmt.Sprintf("%.1f MB", float64(n)/float64(mb))
+	case n >= kb:
+		return fmt.Sprintf("%.1f KB", float64(n)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}
+
+// estimateTokens returns a rough token count estimate (1 token ≈ 4 chars).
+func estimateTokens(text string) int {
+	return len(text) / 4
+}
+
+// extractAttachments parses @<filepath> tokens from the input string.
+// Valid @tokens that refer to readable files are converted to Attachments;
+// un-resolvable tokens are left in the returned cleaned prompt string.
+func extractAttachments(input string) (string, []copilot.Attachment) {
+	words := strings.Fields(input)
+	var kept []string
+	var attachments []copilot.Attachment
+	for _, w := range words {
+		if !strings.HasPrefix(w, "@") {
+			kept = append(kept, w)
+			continue
+		}
+		path := strings.TrimPrefix(w, "@")
+		if path == "" {
+			kept = append(kept, w)
+			continue
+		}
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			kept = append(kept, w)
+			continue
+		}
+		if _, err := os.Stat(abs); err != nil {
+			kept = append(kept, w)
+			continue
+		}
+		pathCopy := abs
+		nameCopy := filepath.Base(abs)
+		attachments = append(attachments, copilot.Attachment{
+			Type:        copilot.AttachmentTypeFile,
+			Path:        &pathCopy,
+			DisplayName: &nameCopy,
+		})
+	}
+	return strings.Join(kept, " "), attachments
+}
+
+// copyToClipboard copies text to the system clipboard.
+func copyToClipboard(text string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("pbcopy") // #nosec G204
+	case "windows":
+		cmd = exec.Command("clip") // #nosec G204
+	default:
+		if _, err := exec.LookPath("xclip"); err == nil {
+			cmd = exec.Command("xclip", "-sel", "clip") // #nosec G204
+		} else if _, err := exec.LookPath("xsel"); err == nil {
+			cmd = exec.Command("xsel", "--clipboard", "--input") // #nosec G204
+		} else {
+			return fmt.Errorf("no clipboard utility found (install xclip or xsel)")
+		}
+	}
+	cmd.Stdin = strings.NewReader(text)
+	return cmd.Run()
+}
+
+// handleShellPassthrough executes a shell command directly, bypassing the AI.
+func handleShellPassthrough(cmdStr string) {
+	cmdStr = strings.TrimSpace(cmdStr)
+	if cmdStr == "" {
+		return
+	}
+	fmt.Printf("  %s$ %s%s\n", colorDim, cmdStr, colorReset)
+	cmd := exec.Command("sh", "-c", cmdStr) // #nosec G204
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			fmt.Printf("  %s●%s Exit code: %d\n", colorYellow, colorReset, exitErr.ExitCode())
+		} else {
+			fmt.Printf(fmtErrorBullet, colorRed, colorReset, err)
+		}
+	}
+}
+
+// onDeltaEvent handles an incremental streaming delta from the assistant.
+func onDeltaEvent(event copilot.SessionEvent) {
+	if event.Data.DeltaContent == nil || *event.Data.DeltaContent == "" {
+		return
+	}
+	if !streamingActive.Swap(true) {
+		// First delta: suppress spinner and clear the spinner line
+		spinnerPaused.Store(1)
+		time.Sleep(120 * time.Millisecond)
+		fmt.Printf("\r\033[K\n")
+	}
+	fmt.Print(*event.Data.DeltaContent)
+}
+
+// printUsage prints a session usage summary for the /usage command.
+func printUsage(state *agentState) {
+	elapsed := time.Since(state.sessionStart)
+	h := int(elapsed.Hours())
+	m := int(elapsed.Minutes()) % 60
+	s := int(elapsed.Seconds()) % 60
+	var dur string
+	switch {
+	case h > 0:
+		dur = fmt.Sprintf("%dh %dm %ds", h, m, s)
+	case m > 0:
+		dur = fmt.Sprintf("%dm %ds", m, s)
+	default:
+		dur = fmt.Sprintf("%ds", s)
+	}
+	fmt.Println()
+	fmt.Printf("  %s━━ Session Usage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━%s\n", colorCyan, colorReset)
+	fmt.Println()
+	fmt.Printf("  Duration:       %s\n", dur)
+	fmt.Printf("  Turns:          %d\n", state.turnCount)
+	if !state.quotaUnlimited && state.quotaTotal > 0 {
+		used := state.quotaUsed - state.premiumUsedAtStart
+		fmt.Printf("  Premium quota:  %.0f used this session (%.0f%% remaining)\n", used, state.quotaPercentage)
+	} else {
+		fmt.Printf("  Premium quota:  unlimited\n")
+	}
+	if state.turnsMiniCount > 0 || state.turnsGPT4Count > 0 {
+		fmt.Printf("  Models used:    %s ×%d, %s ×%d\n",
+			modelCostEffective, state.turnsMiniCount,
+			modelPremium, state.turnsGPT4Count)
+	}
+	if state.forcedModel != "" {
+		fmt.Printf("  Model forced:   %s\n", state.forcedModel)
+	}
+	fmt.Println()
+}
+
+// handleClear resets the conversation by creating a fresh session.
+func handleClear(deps *loopDeps, ts *turnState) error {
+	newSession, err := switchToModel(deps, ts.session, ts.model)
+	if err != nil {
+		return err
+	}
+	ts.session = newSession
+	deps.state.turnCount = 0
+	deps.state.turnsMiniCount = 0
+	deps.state.turnsGPT4Count = 0
+	deps.state.sessionStart = time.Now()
+	deps.state.premiumUsedAtStart = deps.state.quotaUsed
+	fmt.Printf("  %s●%s Conversation cleared — new session started\n", colorGreen, colorReset)
+	return nil
+}
+
+// handleCompact summarises the conversation history and starts a fresh context window.
+func handleCompact(deps *loopDeps, ts *turnState) error {
+	if deps.state.turnCount == 0 {
+		fmt.Printf("  %s●%s Nothing to compact — no turns yet\n", colorYellow, colorReset)
+		return nil
+	}
+	fmt.Printf("  %s●%s Compacting conversation history...\n", colorCyan, colorReset)
+	const compactPrompt = "Summarize our entire conversation so far in 3-5 sentences, focusing on the key Kubernetes findings, issues discussed, and conclusions reached. Be factual and specific."
+	*deps.isIdle = false
+	if _, err := ts.session.Send(deps.ctx, copilot.MessageOptions{Prompt: compactPrompt}); err != nil {
+		return fmt.Errorf("failed to send compact prompt: %w", err)
+	}
+	waitForIdleWithSpinner(deps.isIdle)
+	summary := deps.state.lastResponseText
+	prevTurns := deps.state.turnCount
+	newSession, err := switchToModel(deps, ts.session, ts.model)
+	if err != nil {
+		return err
+	}
+	ts.session = newSession
+	deps.state.turnCount = 0
+	deps.state.turnsMiniCount = 0
+	deps.state.turnsGPT4Count = 0
+	deps.state.premiumUsedAtStart = deps.state.quotaUsed
+	deps.state.sessionStart = time.Now()
+	if summary != "" {
+		contextPrompt := fmt.Sprintf("[CONTEXT FROM PREVIOUS SESSION (%d turns)]\n%s\n[END CONTEXT]", prevTurns, summary)
+		*deps.isIdle = false
+		if _, err := ts.session.Send(deps.ctx, copilot.MessageOptions{Prompt: contextPrompt}); err != nil {
+			log.Printf("Warning: failed to inject compact summary: %v", err)
+		} else {
+			waitForIdle(deps.isIdle)
+		}
+	}
+	fmt.Printf("  %s●%s Session compacted: %d turns → summary (~%d tokens)\n",
+		colorGreen, colorReset, prevTurns, estimateTokens(summary))
+	return nil
+}
+
+// handleModelCommand processes the /model command for mid-session model switching.
+// Returns (handled bool, err error).
+func handleModelCommand(deps *loopDeps, input string, ts *turnState) (bool, error) {
+	parts := strings.Fields(input)
+	if len(parts) == 1 {
+		if deps.state.forcedModel != "" {
+			fmt.Printf("  %s●%s Model override: %s%s%s (auto-routing disabled)\n",
+				colorCyan, colorReset, colorCyan, deps.state.forcedModel, colorReset)
+		} else {
+			fmt.Printf("  %s●%s Auto model routing: %s (simple) / %s (complex)\n",
+				colorCyan, colorReset, modelCostEffective, modelPremium)
+		}
+		fmt.Printf("  %s  /model <name> to override • /model reset to restore auto-routing%s\n", colorDim, colorReset)
+		return true, nil
+	}
+	if strings.ToLower(parts[1]) == "reset" {
+		deps.state.forcedModel = ""
+		fmt.Printf("  %s●%s Auto model routing restored\n", colorGreen, colorReset)
+		return true, nil
+	}
+	newModel := parts[1]
+	newSession, err := switchToModel(deps, ts.session, newModel)
+	if err != nil {
+		return true, err
+	}
+	deps.state.forcedModel = newModel
+	ts.session = newSession
+	ts.model = newModel
+	fmt.Printf("  %s●%s Model overridden: %s%s%s\n", colorGreen, colorReset, colorCyan, newModel, colorReset)
+	fmt.Printf("  %s  Use /model reset to re-enable auto-routing%s\n", colorDim, colorReset)
+	return true, nil
+}
+
+// handleContextCommand processes /context list and /context use <name> commands.
+func handleContextCommand(deps *loopDeps, input string) (bool, error) {
+	parts := strings.Fields(input)
+	if len(parts) == 1 || (len(parts) == 2 && strings.ToLower(parts[1]) == "list") {
+		clusters := deps.k8sProvider.GetClusters()
+		current := deps.k8sProvider.GetCurrentContext()
+		fmt.Println()
+		fmt.Printf("  %s━━ Kubernetes Contexts ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━%s\n", colorCyan, colorReset)
+		fmt.Println()
+		for _, c := range clusters {
+			if c.Context == current {
+				fmt.Printf("  %s* %-44s (current)%s\n", colorCyan, c.Context, colorReset)
+			} else {
+				fmt.Printf("    %s\n", c.Context)
+			}
+		}
+		fmt.Println()
+		return true, nil
+	}
+	if len(parts) >= 3 && strings.ToLower(parts[1]) == "use" {
+		newCtx := parts[2]
+		oldCtx := deps.k8sProvider.GetCurrentContext()
+		if err := deps.k8sProvider.SetCurrentContext(newCtx); err != nil {
+			fmt.Printf(fmtErrorBullet, colorRed, colorReset, err)
+			return true, nil
+		}
+		fmt.Printf("  %s●%s Active context: %s%s%s → %s%s%s\n",
+			colorGreen, colorReset,
+			colorDim, oldCtx, colorReset,
+			colorCyan, newCtx, colorReset)
+		return true, nil
+	}
+	fmt.Printf("  %s●%s Usage: /context list  or  /context use <name>\n", colorRed, colorReset)
+	return true, nil
+}
+
+// dispatchUXCommand handles the new UX-related slash commands introduced in this release.
+// Returns (handled bool, err error).
+func dispatchUXCommand(deps *loopDeps, input string, ts *turnState) (bool, error) {
+	lower := strings.TrimSpace(strings.ToLower(input))
+	switch {
+	case lower == "/clear" || lower == "/new":
+		return true, handleClear(deps, ts)
+	case lower == "/usage":
+		printUsage(deps.state)
+		return true, nil
+	case lower == "/compact":
+		return true, handleCompact(deps, ts)
+	case lower == "/last":
+		if deps.state.lastResponseText == "" {
+			fmt.Printf("  %s●%s No previous response to show\n", colorDim, colorReset)
+		} else {
+			fmt.Println()
+			fmt.Println(deps.state.lastResponseText)
+		}
+		return true, nil
+	case lower == "/copy":
+		if deps.state.lastResponseText == "" {
+			fmt.Printf("  %s●%s Nothing to copy yet\n", colorDim, colorReset)
+			return true, nil
+		}
+		if err := copyToClipboard(deps.state.lastResponseText); err != nil {
+			fmt.Printf(fmtErrorBullet, colorRed, colorReset, err)
+			return true, nil
+		}
+		fmt.Printf("  %s●%s Copied to clipboard (%d characters)\n",
+			colorGreen, colorReset, len(deps.state.lastResponseText))
+		return true, nil
+	case lower == "/streamer" || strings.HasPrefix(lower, "/streamer "):
+		parts := strings.Fields(input)
+		if len(parts) >= 2 {
+			switch strings.ToLower(parts[1]) {
+			case "on":
+				deps.state.streamerMode = true
+			case "off":
+				deps.state.streamerMode = false
+			default:
+				fmt.Printf("  %s●%s Usage: /streamer [on|off]\n", colorRed, colorReset)
+				return true, nil
+			}
+		} else {
+			deps.state.streamerMode = !deps.state.streamerMode
+		}
+		if deps.state.streamerMode {
+			fmt.Printf("  %s●%s Streamer mode on — quota info hidden\n", colorGreen, colorReset)
+		} else {
+			fmt.Printf("  %s●%s Streamer mode off\n", colorGreen, colorReset)
+		}
+		return true, nil
+	case strings.HasPrefix(lower, "/model"):
+		return handleModelCommand(deps, input, ts)
+	case strings.HasPrefix(lower, "/context"):
+		return handleContextCommand(deps, input)
+	}
+	return false, nil
 }
 
 // interactiveLoopWithModelSelection handles interactive conversation with dynamic model selection.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1661,33 +1661,62 @@ func printLongRunningWarning(agentType AgentType) {
 }
 
 // sendToModel selects the best model for the query and sends it, updating ts as needed.
+// printAttachments logs attachment info for non-JSON output.
+func printAttachments(attachments []copilot.Attachment, outputFormat OutputFormat) {
+	if isJSONOutput(outputFormat) {
+		return
+	}
+	for _, a := range attachments {
+		if a.Path == nil {
+			continue
+		}
+		fi, err := os.Stat(*a.Path)
+		if err != nil {
+			continue
+		}
+		dname := ""
+		if a.DisplayName != nil {
+			dname = *a.DisplayName
+		}
+		fmt.Printf("  %s📎 Attached: %s (%s)%s\n", colorCyan, dname, formatBytes(fi.Size()), colorReset)
+	}
+}
+
+// maybeSwapModel switches the session to the optimal model if it differs from the current one.
+func maybeSwapModel(deps *loopDeps, ts *turnState, prompt string) error {
+	optimalModel := selectModelForQuery(prompt, deps.state.selectedAgent, deps.state.forcedModel)
+	if optimalModel == ts.model {
+		return nil
+	}
+	newSession, err := switchToModel(deps, ts.session, optimalModel)
+	if err != nil {
+		return err
+	}
+	ts.session = newSession
+	ts.model = optimalModel
+	return nil
+}
+
+// trackTurnModelUsage increments per-turn counters based on the model used.
+func trackTurnModelUsage(state *agentState, model string) {
+	state.turnCount++
+	if model == modelCostEffective {
+		state.turnsMiniCount++
+	} else {
+		state.turnsGPT4Count++
+	}
+}
+
 func sendToModel(deps *loopDeps, ts *turnState, input string) error {
 	// @ file attachment injection
 	prompt, attachments := extractAttachments(input)
-	if len(attachments) > 0 && !isJSONOutput(deps.state.outputFormat) {
-		for _, a := range attachments {
-			if a.Path != nil {
-				if fi, err := os.Stat(*a.Path); err == nil {
-					dname := ""
-					if a.DisplayName != nil {
-						dname = *a.DisplayName
-					}
-					fmt.Printf("  %s📎 Attached: %s (%s)%s\n", colorCyan, dname, formatBytes(fi.Size()), colorReset)
-				}
-			}
-		}
-	}
+	printAttachments(attachments, deps.state.outputFormat)
 	if prompt == "" {
 		prompt = input // fallback if all tokens were attachments
 	}
 
-	if optimalModel := selectModelForQuery(prompt, deps.state.selectedAgent, deps.state.forcedModel); optimalModel != ts.model {
-		newSession, err := switchToModel(deps, ts.session, optimalModel)
-		if err != nil {
-			return err
-		}
-		ts.session = newSession
-		ts.model = optimalModel
+	if err := maybeSwapModel(deps, ts, prompt); err != nil {
+		return err
 	}
 	if !isJSONOutput(deps.state.outputFormat) && isLongRunningQuery(prompt, deps.state.selectedAgent) {
 		printLongRunningWarning(deps.state.selectedAgent)
@@ -1707,13 +1736,7 @@ func sendToModel(deps *loopDeps, ts *turnState, input string) error {
 		deps.state.setAbortCurrentTurn(nil)
 		return fmt.Errorf("failed to send message: %w", err)
 	}
-	// Track per-turn model usage
-	deps.state.turnCount++
-	if ts.model == modelCostEffective {
-		deps.state.turnsMiniCount++
-	} else {
-		deps.state.turnsGPT4Count++
-	}
+	trackTurnModelUsage(deps.state, ts.model)
 	return nil
 }
 
@@ -1896,11 +1919,14 @@ func printUsage(state *agentState) {
 	fmt.Println()
 	fmt.Printf("  Duration:       %s\n", dur)
 	fmt.Printf("  Turns:          %d\n", state.turnCount)
-	if !state.quotaUnlimited && state.quotaTotal > 0 {
+	switch {
+	case state.quotaUnlimited:
+		fmt.Printf("  Premium quota:  unlimited\n")
+	case state.quotaTotal > 0:
 		used := state.quotaUsed - state.premiumUsedAtStart
 		fmt.Printf("  Premium quota:  %.0f used this session (%.0f%% remaining)\n", used, state.quotaPercentage)
-	} else {
-		fmt.Printf("  Premium quota:  unlimited\n")
+	default:
+		fmt.Printf("  Premium quota:  not yet available (send a message first)\n")
 	}
 	if state.turnsMiniCount > 0 || state.turnsGPT4Count > 0 {
 		fmt.Printf("  Models used:    %s ×%d, %s ×%d\n",

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -398,8 +398,8 @@ func ParseAgentType(s string) (AgentType, error) {
 
 const (
 	// Default model selection constants
-	defaultModelCostEffective = "gpt-4o-mini" // Cost-effective model for simple queries
-	defaultModelPremium       = "gpt-4o"      // Premium model for complex tasks
+	defaultModelCostEffective = "gpt-4.1"           // Cost-effective model for simple queries
+	defaultModelPremium       = "claude-sonnet-4.6" // Premium model for complex tasks
 
 	// ANSI color codes
 	colorReset     = "\033[0m"
@@ -618,19 +618,23 @@ const maxDisplayLines = 30
 // When streaming was active the content was already printed incrementally;
 // this function only stores it and closes the streaming state in that case.
 func onMessageEvent(event copilot.SessionEvent, state *agentState) {
+	d, ok := event.Data.(*copilot.AssistantMessageData)
+	if !ok {
+		return
+	}
 	if streamingActive.Swap(false) {
 		// Content was already streamed incrementally — just finalise
 		fmt.Println()
 		spinnerPaused.Store(0)
-		if event.Data.Content != nil {
-			state.setLastResponse(*event.Data.Content)
+		if d.Content != "" {
+			state.setLastResponse(d.Content)
 		}
 		return
 	}
-	if event.Data.Content == nil || *event.Data.Content == "" {
+	if d.Content == "" {
 		return
 	}
-	content := *event.Data.Content
+	content := d.Content
 	state.setLastResponse(content)
 	fmt.Println()
 	lines := strings.Split(content, "\n")
@@ -648,32 +652,32 @@ func onMessageEvent(event copilot.SessionEvent, state *agentState) {
 
 // onSessionErrorEvent prints errors from session.error events to the user.
 func onSessionErrorEvent(event copilot.SessionEvent) {
-	d := event.Data
+	d, ok := event.Data.(*copilot.SessionErrorData)
+	if !ok {
+		return
+	}
 	msg := "(unknown session error)"
-	if d.Message != nil && *d.Message != "" {
-		msg = *d.Message
+	if d.Message != "" {
+		msg = d.Message
 	}
 	code := ""
 	if d.StatusCode != nil {
 		code = fmt.Sprintf(" [status %d]", *d.StatusCode)
 	}
 	errType := ""
-	if d.ErrorType != nil && *d.ErrorType != "" {
-		errType = fmt.Sprintf(" [%s]", *d.ErrorType)
+	if d.ErrorType != "" {
+		errType = fmt.Sprintf(" [%s]", d.ErrorType)
 	}
-	reason := ""
-	if d.ErrorReason != nil && *d.ErrorReason != "" {
-		reason = fmt.Sprintf(" (reason: %s)", *d.ErrorReason)
-	}
-	fmt.Fprintf(os.Stderr, "Error%s%s: %s%s\n", code, errType, msg, reason)
+	fmt.Fprintf(os.Stderr, "Error%s%s: %s\n", code, errType, msg)
 }
 
 // onUsageEvent records quota information from usage snapshots.
 func onUsageEvent(event copilot.SessionEvent, state *agentState) {
-	if event.Data.QuotaSnapshots == nil {
+	d, ok := event.Data.(*copilot.AssistantUsageData)
+	if !ok || d.QuotaSnapshots == nil {
 		return
 	}
-	snapshot, exists := event.Data.QuotaSnapshots["premium_interactions"]
+	snapshot, exists := d.QuotaSnapshots["premium_interactions"]
 	if exists && snapshot.RemainingPercentage >= 0 {
 		state.quotaPercentage = snapshot.RemainingPercentage
 		state.quotaUnlimited = snapshot.IsUnlimitedEntitlement
@@ -688,7 +692,7 @@ func setupSessionEventHandler(session *copilot.Session, isIdlePtr *bool, state *
 		switch event.Type {
 		case "assistant.message":
 			onMessageEvent(event, state)
-		case "assistant.message.delta":
+		case "assistant.message_delta":
 			onDeltaEvent(event)
 		case "session.error":
 			onSessionErrorEvent(event)
@@ -1859,7 +1863,8 @@ func handleShellPassthrough(cmdStr string) {
 
 // onDeltaEvent handles an incremental streaming delta from the assistant.
 func onDeltaEvent(event copilot.SessionEvent) {
-	if event.Data.DeltaContent == nil || *event.Data.DeltaContent == "" {
+	d, ok := event.Data.(*copilot.AssistantMessageDeltaData)
+	if !ok || d.DeltaContent == "" {
 		return
 	}
 	if !streamingActive.Swap(true) {
@@ -1868,7 +1873,7 @@ func onDeltaEvent(event copilot.SessionEvent) {
 		time.Sleep(120 * time.Millisecond)
 		fmt.Printf("\r\033[K\n")
 	}
-	fmt.Print(*event.Data.DeltaContent)
+	fmt.Print(d.DeltaContent)
 }
 
 // printUsage prints a session usage summary for the /usage command.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1755,6 +1755,14 @@ func extractAttachments(input string) (string, []copilot.Attachment) {
 			kept = append(kept, w)
 			continue
 		}
+		f, openErr := os.Open(abs) // #nosec G304 — path is already resolved via filepath.Abs
+		if openErr != nil {
+			kept = append(kept, w)
+			continue
+		}
+		if closeErr := f.Close(); closeErr != nil {
+			log.Printf("Warning: failed to close attachment file %s: %v", abs, closeErr)
+		}
 		pathCopy := abs
 		nameCopy := filepath.Base(abs)
 		attachments = append(attachments, copilot.Attachment{

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -764,5 +765,467 @@ func TestLastResponseMutex(t *testing.T) {
 	<-done
 	if got := state.getLastResponse(); got != value {
 		t.Errorf("getLastResponse() = %q, want %q", got, value)
+	}
+}
+
+// TestFormatBytes exercises all three branches: bytes, KB, and MB.
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1024 * 1024, "1.0 MB"},
+		{1024*1024*2 + 1024*512, "2.5 MB"},
+	}
+	for _, tt := range tests {
+		got := formatBytes(tt.input)
+		if got != tt.want {
+			t.Errorf("formatBytes(%d) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+// TestEstimateTokens verifies the rough token count heuristic (1 token ≈ 4 chars).
+func TestEstimateTokens(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"", 0},
+		{"abcd", 1},
+		{"abcdefgh", 2},
+		{"hello world!", 3},
+	}
+	for _, tt := range tests {
+		got := estimateTokens(tt.input)
+		if got != tt.want {
+			t.Errorf("estimateTokens(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+// TestHandleLastEmpty verifies /last with no previous response.
+func TestHandleLastEmpty(t *testing.T) {
+	state := &agentState{}
+	handled, err := handleLast(state)
+	if err != nil {
+		t.Fatalf("handleLast returned unexpected error: %v", err)
+	}
+	if !handled {
+		t.Error("handleLast should return handled=true")
+	}
+}
+
+// TestHandleLastWithContent verifies /last prints the stored response.
+func TestHandleLastWithContent(t *testing.T) {
+	state := &agentState{}
+	state.setLastResponse("some assistant response")
+	handled, err := handleLast(state)
+	if err != nil {
+		t.Fatalf("handleLast returned unexpected error: %v", err)
+	}
+	if !handled {
+		t.Error("handleLast should return handled=true")
+	}
+}
+
+// TestHandleCopyEmpty verifies /copy when there is nothing in the buffer.
+func TestHandleCopyEmpty(t *testing.T) {
+	state := &agentState{}
+	handled, err := handleCopy(state)
+	if err != nil {
+		t.Fatalf("handleCopy returned unexpected error: %v", err)
+	}
+	if !handled {
+		t.Error("handleCopy should return handled=true")
+	}
+}
+
+// TestHandleCopyWithContent verifies /copy when the buffer has content.
+// copyToClipboard may succeed (macOS) or fail (CI without xclip/xsel) — either
+// branch provides coverage; only the "nothing to copy" early-return is omitted.
+func TestHandleCopyWithContent(t *testing.T) {
+	state := &agentState{}
+	state.setLastResponse("response to copy")
+	handled, err := handleCopy(state)
+	if err != nil {
+		t.Fatalf("handleCopy returned unexpected error: %v", err)
+	}
+	if !handled {
+		t.Error("handleCopy should return handled=true")
+	}
+}
+
+// TestHandleStreamerToggle verifies that /streamer without arguments toggles the flag.
+func TestHandleStreamerToggle(t *testing.T) {
+	state := &agentState{streamerMode: false}
+
+	handled, err := handleStreamer(state, "/streamer")
+	if err != nil || !handled {
+		t.Fatalf("handleStreamer toggle: handled=%v err=%v", handled, err)
+	}
+	if !state.streamerMode {
+		t.Error("expected streamerMode=true after first toggle")
+	}
+
+	handled, err = handleStreamer(state, "/streamer")
+	if err != nil || !handled {
+		t.Fatalf("handleStreamer toggle back: handled=%v err=%v", handled, err)
+	}
+	if state.streamerMode {
+		t.Error("expected streamerMode=false after second toggle")
+	}
+}
+
+// TestHandleStreamerExplicit verifies /streamer on and /streamer off.
+func TestHandleStreamerExplicit(t *testing.T) {
+	state := &agentState{}
+
+	if _, err := handleStreamer(state, "/streamer on"); err != nil {
+		t.Fatal(err)
+	}
+	if !state.streamerMode {
+		t.Error("expected streamerMode=true after '/streamer on'")
+	}
+
+	if _, err := handleStreamer(state, "/streamer off"); err != nil {
+		t.Fatal(err)
+	}
+	if state.streamerMode {
+		t.Error("expected streamerMode=false after '/streamer off'")
+	}
+}
+
+// TestHandleStreamerInvalid verifies that an unknown argument is rejected gracefully.
+func TestHandleStreamerInvalid(t *testing.T) {
+	state := &agentState{}
+	handled, err := handleStreamer(state, "/streamer maybe")
+	if err != nil {
+		t.Fatalf("handleStreamer invalid arg returned error: %v", err)
+	}
+	if !handled {
+		t.Error("handleStreamer should return handled=true even for invalid arg")
+	}
+}
+
+// TestHandleModelCommandNoArgs verifies /model with no arguments prints status.
+func TestHandleModelCommandNoArgs(t *testing.T) {
+	provider := createMockProvider(t)
+	idle := true
+	deps := &loopDeps{
+		ctx:         context.Background(),
+		k8sProvider: provider,
+		state:       &agentState{},
+		isIdle:      &idle,
+	}
+	ts := &turnState{model: modelCostEffective}
+
+	handled, err := handleModelCommand(deps, "/model", ts)
+	if err != nil {
+		t.Fatalf("handleModelCommand(/model) returned error: %v", err)
+	}
+	if !handled {
+		t.Error("handleModelCommand(/model) should return handled=true")
+	}
+}
+
+// TestHandleModelCommandNoArgsWithForced verifies /model displays forced model info.
+func TestHandleModelCommandNoArgsWithForced(t *testing.T) {
+	provider := createMockProvider(t)
+	idle := true
+	deps := &loopDeps{
+		ctx:         context.Background(),
+		k8sProvider: provider,
+		state:       &agentState{forcedModel: "gpt-4o"},
+		isIdle:      &idle,
+	}
+	ts := &turnState{model: "gpt-4o"}
+
+	handled, err := handleModelCommand(deps, "/model", ts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !handled {
+		t.Error("should be handled")
+	}
+}
+
+// TestHandleModelCommandReset verifies /model reset clears the forced model.
+func TestHandleModelCommandReset(t *testing.T) {
+	provider := createMockProvider(t)
+	idle := true
+	deps := &loopDeps{
+		ctx:         context.Background(),
+		k8sProvider: provider,
+		state:       &agentState{forcedModel: "gpt-4o"},
+		isIdle:      &idle,
+	}
+	ts := &turnState{model: "gpt-4o"}
+
+	handled, err := handleModelCommand(deps, "/model reset", ts)
+	if err != nil {
+		t.Fatalf("handleModelCommand(/model reset) returned error: %v", err)
+	}
+	if !handled {
+		t.Error("handleModelCommand(/model reset) should return handled=true")
+	}
+	if deps.state.forcedModel != "" {
+		t.Errorf("forcedModel should be cleared, got %q", deps.state.forcedModel)
+	}
+}
+
+// TestHandleContextCommandList verifies /context list via the mock provider.
+func TestHandleContextCommandList(t *testing.T) {
+	provider := createMockProvider(t)
+	idle := true
+	deps := &loopDeps{
+		ctx:         context.Background(),
+		k8sProvider: provider,
+		state:       &agentState{},
+		isIdle:      &idle,
+	}
+
+	for _, input := range []string{"/context", "/context list", "/context LIST"} {
+		handled, err := handleContextCommand(deps, input)
+		if err != nil {
+			t.Fatalf("handleContextCommand(%q) returned error: %v", input, err)
+		}
+		if !handled {
+			t.Errorf("handleContextCommand(%q) should return handled=true", input)
+		}
+	}
+}
+
+// TestHandleContextCommandUse verifies /context use <name> switches the active context.
+func TestHandleContextCommandUse(t *testing.T) {
+	provider := createMockProvider(t)
+	clusters := provider.GetClusters()
+	if len(clusters) == 0 {
+		t.Skip("no clusters in mock provider")
+	}
+	targetCtx := clusters[0].Context
+
+	idle := true
+	deps := &loopDeps{
+		ctx:         context.Background(),
+		k8sProvider: provider,
+		state:       &agentState{},
+		isIdle:      &idle,
+	}
+
+	handled, err := handleContextCommand(deps, "/context use "+targetCtx)
+	if err != nil {
+		t.Fatalf("handleContextCommand(/context use ...) returned error: %v", err)
+	}
+	if !handled {
+		t.Error("should return handled=true")
+	}
+	if provider.GetCurrentContext() != targetCtx {
+		t.Errorf("current context = %q, want %q", provider.GetCurrentContext(), targetCtx)
+	}
+}
+
+// TestHandleContextCommandInvalid verifies /context with bad syntax is gracefully rejected.
+func TestHandleContextCommandInvalid(t *testing.T) {
+	provider := createMockProvider(t)
+	idle := true
+	deps := &loopDeps{
+		ctx:         context.Background(),
+		k8sProvider: provider,
+		state:       &agentState{},
+		isIdle:      &idle,
+	}
+
+	handled, err := handleContextCommand(deps, "/context badcmd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !handled {
+		t.Error("should return handled=true")
+	}
+}
+
+// TestPrintUsage exercises printUsage under several quota conditions.
+func TestPrintUsage(t *testing.T) {
+	tests := []struct {
+		name  string
+		state *agentState
+	}{
+		{
+			name: "unlimited quota",
+			state: &agentState{
+				sessionStart:   time.Now().Add(-90 * time.Second),
+				quotaUnlimited: true,
+				turnCount:      5,
+				turnsMiniCount: 3,
+				turnsGPT4Count: 2,
+			},
+		},
+		{
+			name: "limited quota",
+			state: &agentState{
+				sessionStart:       time.Now().Add(-2 * time.Minute),
+				quotaUnlimited:     false,
+				quotaTotal:         100,
+				quotaUsed:          40,
+				premiumUsedAtStart: 30,
+				quotaPercentage:    60,
+				turnCount:          3,
+			},
+		},
+		{
+			name: "hours elapsed",
+			state: &agentState{
+				sessionStart:   time.Now().Add(-70 * time.Minute),
+				quotaUnlimited: true,
+				forcedModel:    "gpt-4o",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// printUsage writes to stdout; we just ensure it doesn't panic.
+			printUsage(tt.state)
+		})
+	}
+}
+
+// TestDispatchUXCommandLast verifies /last is routed and handled.
+func TestDispatchUXCommandLast(t *testing.T) {
+	provider := createMockProvider(t)
+	idle := true
+	state := &agentState{}
+	state.setLastResponse("response text")
+	deps := &loopDeps{
+		ctx:         context.Background(),
+		k8sProvider: provider,
+		state:       state,
+		isIdle:      &idle,
+	}
+	ts := &turnState{model: modelCostEffective}
+
+	handled, err := dispatchUXCommand(deps, "/last", ts)
+	if err != nil || !handled {
+		t.Errorf("dispatchUXCommand(/last): handled=%v err=%v", handled, err)
+	}
+}
+
+// TestDispatchUXCommandUsage verifies /usage is routed and handled.
+func TestDispatchUXCommandUsage(t *testing.T) {
+	provider := createMockProvider(t)
+	idle := true
+	deps := &loopDeps{
+		ctx:         context.Background(),
+		k8sProvider: provider,
+		state:       &agentState{sessionStart: time.Now(), quotaUnlimited: true},
+		isIdle:      &idle,
+	}
+	ts := &turnState{}
+
+	handled, err := dispatchUXCommand(deps, "/usage", ts)
+	if err != nil || !handled {
+		t.Errorf("dispatchUXCommand(/usage): handled=%v err=%v", handled, err)
+	}
+}
+
+// TestDispatchUXCommandStreamer verifies /streamer is dispatched.
+func TestDispatchUXCommandStreamer(t *testing.T) {
+	provider := createMockProvider(t)
+	idle := true
+	deps := &loopDeps{
+		ctx:         context.Background(),
+		k8sProvider: provider,
+		state:       &agentState{},
+		isIdle:      &idle,
+	}
+	ts := &turnState{}
+
+	for _, cmd := range []string{"/streamer", "/streamer on", "/streamer off"} {
+		handled, err := dispatchUXCommand(deps, cmd, ts)
+		if err != nil || !handled {
+			t.Errorf("dispatchUXCommand(%q): handled=%v err=%v", cmd, handled, err)
+		}
+	}
+}
+
+// TestDispatchUXCommandCopy verifies /copy is dispatched (empty buffer case).
+func TestDispatchUXCommandCopy(t *testing.T) {
+	provider := createMockProvider(t)
+	idle := true
+	deps := &loopDeps{
+		ctx:         context.Background(),
+		k8sProvider: provider,
+		state:       &agentState{},
+		isIdle:      &idle,
+	}
+	ts := &turnState{}
+
+	handled, err := dispatchUXCommand(deps, "/copy", ts)
+	if err != nil || !handled {
+		t.Errorf("dispatchUXCommand(/copy): handled=%v err=%v", handled, err)
+	}
+}
+
+// TestDispatchUXCommandModel verifies /model and /model reset are dispatched.
+func TestDispatchUXCommandModel(t *testing.T) {
+	provider := createMockProvider(t)
+	idle := true
+	deps := &loopDeps{
+		ctx:         context.Background(),
+		k8sProvider: provider,
+		state:       &agentState{forcedModel: "gpt-4o"},
+		isIdle:      &idle,
+	}
+	ts := &turnState{model: "gpt-4o"}
+
+	for _, cmd := range []string{"/model", "/model reset"} {
+		handled, err := dispatchUXCommand(deps, cmd, ts)
+		if err != nil || !handled {
+			t.Errorf("dispatchUXCommand(%q): handled=%v err=%v", cmd, handled, err)
+		}
+	}
+}
+
+// TestDispatchUXCommandContext verifies /context list is dispatched.
+func TestDispatchUXCommandContext(t *testing.T) {
+	provider := createMockProvider(t)
+	idle := true
+	deps := &loopDeps{
+		ctx:         context.Background(),
+		k8sProvider: provider,
+		state:       &agentState{},
+		isIdle:      &idle,
+	}
+	ts := &turnState{}
+
+	handled, err := dispatchUXCommand(deps, "/context list", ts)
+	if err != nil || !handled {
+		t.Errorf("dispatchUXCommand(/context list): handled=%v err=%v", handled, err)
+	}
+}
+
+// TestDispatchUXCommandUnknown verifies that unknown commands return handled=false.
+func TestDispatchUXCommandUnknown(t *testing.T) {
+	provider := createMockProvider(t)
+	idle := true
+	deps := &loopDeps{
+		ctx:         context.Background(),
+		k8sProvider: provider,
+		state:       &agentState{},
+		isIdle:      &idle,
+	}
+	ts := &turnState{}
+
+	handled, err := dispatchUXCommand(deps, "/unknown", ts)
+	if err != nil {
+		t.Fatalf("unexpected error for unknown command: %v", err)
+	}
+	if handled {
+		t.Error("dispatchUXCommand should return handled=false for unknown commands")
 	}
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -613,3 +613,156 @@ func TestSanitizerAgentDefinition(t *testing.T) {
 		t.Error("AgentSanitizer should have at least one example")
 	}
 }
+
+// TestExtractAttachments exercises the @<filepath> parsing logic.
+func TestExtractAttachments(t *testing.T) {
+	// Create a temporary regular file we can read.
+	tmpDir := t.TempDir()
+	regularFile := filepath.Join(tmpDir, "hello.txt")
+	if err := os.WriteFile(regularFile, []byte("hello"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a subdirectory (not a regular file).
+	subDir := filepath.Join(tmpDir, "subdir")
+	if err := os.Mkdir(subDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name            string
+		input           string
+		wantPrompt      string
+		wantAttachCount int
+	}{
+		{
+			name:            "no @ tokens",
+			input:           "show me all pods",
+			wantPrompt:      "show me all pods",
+			wantAttachCount: 0,
+		},
+		{
+			name:            "bare @ with no path",
+			input:           "@ show pods",
+			wantPrompt:      "@ show pods",
+			wantAttachCount: 0,
+		},
+		{
+			name:            "non-existent path",
+			input:           "@/no/such/file.txt check it",
+			wantPrompt:      "@/no/such/file.txt check it",
+			wantAttachCount: 0,
+		},
+		{
+			name:            "directory path (not regular file)",
+			input:           "analyse @" + subDir,
+			wantPrompt:      "analyse @" + subDir,
+			wantAttachCount: 0,
+		},
+		{
+			name:            "valid regular file",
+			input:           "read @" + regularFile,
+			wantPrompt:      "read",
+			wantAttachCount: 1,
+		},
+		{
+			name:            "mixed tokens: one valid, one missing",
+			input:           "@" + regularFile + " and @/gone.txt",
+			wantPrompt:      "and @/gone.txt",
+			wantAttachCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPrompt, gotAttach := extractAttachments(tt.input)
+			if gotPrompt != tt.wantPrompt {
+				t.Errorf("prompt = %q, want %q", gotPrompt, tt.wantPrompt)
+			}
+			if len(gotAttach) != tt.wantAttachCount {
+				t.Errorf("attachments count = %d, want %d", len(gotAttach), tt.wantAttachCount)
+			}
+		})
+	}
+}
+
+// TestExtractAttachmentsUnreadable verifies that files that exist but are not
+// readable by the current process are not promoted to attachments.
+func TestExtractAttachmentsUnreadable(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root can read any file — skipping unreadable-file test")
+	}
+	tmpDir := t.TempDir()
+	unreadable := filepath.Join(tmpDir, "secret.txt")
+	if err := os.WriteFile(unreadable, []byte("secret"), 0000); err != nil {
+		t.Fatal(err)
+	}
+	prompt, attachments := extractAttachments("read @" + unreadable)
+	if len(attachments) != 0 {
+		t.Errorf("expected 0 attachments for unreadable file, got %d", len(attachments))
+	}
+	if !strings.Contains(prompt, "@"+unreadable) {
+		t.Errorf("unreadable token should be preserved in prompt, got %q", prompt)
+	}
+}
+
+// TestHistoryFilePath verifies that historyFilePath returns a non-empty path
+// when a home directory is available.
+func TestHistoryFilePath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory available — skipping historyFilePath test")
+	}
+	path := historyFilePath()
+	if path == "" {
+		t.Fatal("historyFilePath() returned empty string when home dir is available")
+	}
+	want := filepath.Join(home, ".kopilot", "history")
+	if path != want {
+		t.Errorf("historyFilePath() = %q, want %q", path, want)
+	}
+	// The directory should have been created.
+	if _, statErr := os.Stat(filepath.Dir(path)); statErr != nil {
+		t.Errorf("historyFilePath() directory not created: %v", statErr)
+	}
+}
+
+// TestSelectModelForcedOverride verifies that a non-empty forcedModel bypasses
+// all keyword-based and agent-type-based routing.
+func TestSelectModelForcedOverride(t *testing.T) {
+	const customModel = "my-custom-model"
+	tests := []struct {
+		name      string
+		query     string
+		agentType AgentType
+	}{
+		{"simple query with forced model", "list pods", AgentDefault},
+		{"complex query with forced model", "troubleshoot crash", AgentDefault},
+		{"specialist agent with forced model", "list pods", AgentDebugger},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectModelForQuery(tt.query, tt.agentType, customModel)
+			if got != customModel {
+				t.Errorf("selectModelForQuery(%q, %q, %q) = %q, want %q",
+					tt.query, tt.agentType, customModel, got, customModel)
+			}
+		})
+	}
+}
+
+// TestLastResponseMutex verifies that setLastResponse / getLastResponse work
+// correctly under concurrent access (data-race detection).
+func TestLastResponseMutex(t *testing.T) {
+	state := &agentState{}
+	const value = "hello from goroutine"
+	done := make(chan struct{})
+	go func() {
+		state.setLastResponse(value)
+		close(done)
+	}()
+	<-done
+	if got := state.getLastResponse(); got != value {
+		t.Errorf("getLastResponse() = %q, want %q", got, value)
+	}
+}

--- a/pkg/agent/model_selection_test.go
+++ b/pkg/agent/model_selection_test.go
@@ -89,11 +89,11 @@ func TestSpecialistAgentsAlwaysUsePremiumModel(t *testing.T) {
 
 func TestModelConstants(t *testing.T) {
 	// Verify the constants have expected values
-	if modelCostEffective != "gpt-4o-mini" {
-		t.Errorf("modelCostEffective = %q, want %q", modelCostEffective, "gpt-4o-mini")
+	if modelCostEffective != "gpt-4.1" {
+		t.Errorf("modelCostEffective = %q, want %q", modelCostEffective, "gpt-4.1")
 	}
 
-	if modelPremium != "gpt-4o" {
-		t.Errorf("modelPremium = %q, want %q", modelPremium, "gpt-4o")
+	if modelPremium != "claude-sonnet-4.6" {
+		t.Errorf("modelPremium = %q, want %q", modelPremium, "claude-sonnet-4.6")
 	}
 }

--- a/pkg/agent/model_selection_test.go
+++ b/pkg/agent/model_selection_test.go
@@ -50,7 +50,7 @@ func TestSelectModelForQuery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := selectModelForQuery(tt.query, AgentDefault)
+			result := selectModelForQuery(tt.query, AgentDefault, "")
 			if result != tt.expectedModel {
 				t.Errorf("selectModelForQuery(%q, AgentDefault) = %q, want %q", tt.query, result, tt.expectedModel)
 			}
@@ -78,7 +78,7 @@ func TestSpecialistAgentsAlwaysUsePremiumModel(t *testing.T) {
 	for _, agent := range specialistAgents {
 		for _, query := range queries {
 			t.Run(fmt.Sprintf("%s/%s", agent, query), func(t *testing.T) {
-				result := selectModelForQuery(query, agent)
+				result := selectModelForQuery(query, agent, "")
 				if result != modelPremium {
 					t.Errorf("selectModelForQuery(%q, %q) = %q, want %q", query, agent, result, modelPremium)
 				}

--- a/pkg/agent/model_selection_test.go
+++ b/pkg/agent/model_selection_test.go
@@ -52,7 +52,7 @@ func TestSelectModelForQuery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := selectModelForQuery(tt.query, AgentDefault, "")
 			if result != tt.expectedModel {
-				t.Errorf("selectModelForQuery(%q, AgentDefault) = %q, want %q", tt.query, result, tt.expectedModel)
+				t.Errorf("selectModelForQuery(%q, AgentDefault, \"\") = %q, want %q", tt.query, result, tt.expectedModel)
 			}
 		})
 	}

--- a/website/docs.md
+++ b/website/docs.md
@@ -180,14 +180,14 @@ Get AI-powered help with:
 
 Kopilot provides two safety modes:
 
-#### 🔒 Read-Only Mode (Default)
+#### 🔒 Read-Only Mode
 
 - Blocks all write operations for maximum safety
 - Allows monitoring, querying, and troubleshooting
 - Best for production environments
 - No risk of accidental changes
 
-#### 🔓 Interactive Mode
+#### 🔓 Interactive Mode (Write Operations)
 
 - Enables write operations with confirmation
 - Shows exact command before execution

--- a/website/docs.md
+++ b/website/docs.md
@@ -70,8 +70,8 @@ Kopilot works with **any model available through your GitHub Copilot subscriptio
 
 **Default configuration:**
 
-- **Cost-effective model** (default: gpt-4o-mini) - Used for simple queries and status checks
-- **Premium model** (default: gpt-4o) - Automatically selected for troubleshooting and complex operations
+- **Cost-effective model** (default: gpt-4.1) - Used for simple queries and status checks
+- **Premium model** (default: claude-sonnet-4.6) - Automatically selected for troubleshooting and complex operations
 
 **Customization:**
 
@@ -86,7 +86,7 @@ export KOPILOT_MODEL_PREMIUM="o1-preview"
 ./bin/kopilot
 ```
 
-Kopilot supports any model available in your GitHub Copilot plan, including: `gpt-4o`, `gpt-4o-mini`, `o1-preview`, `o1-mini`, `claude-3.5-sonnet`, and others.
+Kopilot supports any model available in your GitHub Copilot plan, including: `gpt-4.1`, `claude-sonnet-4.6`, `claude-haiku-4.5`, `gpt-5-mini`, and others.
 
 No API key configuration needed - authentication is handled through GitHub Copilot CLI.
 
@@ -248,8 +248,8 @@ See the [Agents documentation](https://github.com/e9169/kopilot/blob/main/docs/A
 
 Kopilot automatically selects the optimal model based on your query:
 
-- **Simple queries** (list, status, health) → Cost-effective model (default: gpt-4o-mini)
-- **Complex operations** (troubleshooting, scaling, debugging) → Premium model (default: gpt-4o)
+- **Simple queries** (list, status, health) → Cost-effective model (default: gpt-4.1)
+- **Complex operations** (troubleshooting, scaling, debugging) → Premium model (default: claude-sonnet-4.6)
 
 This provides 50-70% cost reduction while maintaining quality for critical tasks. You can customize which models are used via environment variables.
 


### PR DESCRIPTION
## Summary

Implements 14 UI/UX improvements to the kopilot interactive REPL, bringing the experience closer to (and beyond) the GitHub Copilot CLI. Changes are confined to `pkg/agent/agent.go` and the corresponding test file.

## New features

- **Streaming responses**: assistant responses print incrementally via `assistant.message.delta` events; spinner is suppressed during streaming
- **`@<filepath>` attachments**: embed any file as context; parsed from prompt tokens, shown as `📎 Attached: name (size)`
- **`/clear` / `/new`**: start a fresh session and reset all per-session counters
- **`/compact`**: summarise conversation history, start a fresh context window with the summary injected as opening context
- **`/usage`**: show session duration, turn count, model usage breakdown, and estimated token/cost stats
- **`/copy`**: copy the last assistant response to the system clipboard (`pbcopy` / `clip` / `xclip` / `xsel`)
- **`/context list` / `/context use <name>`**: list and switch kubeconfig contexts mid-session
- **`/model <name>`**: switch model mid-session without restarting
- **`!` shell passthrough**: prefix a line with `!` to run it as a shell command directly
- **Persistent readline history**: history is stored in `~/.kopilot/history` across sessions
- **Response truncation**: responses longer than 30 lines are truncated with a `/copy` hint
- **Streamer mode**: quieter prompt when streaming is active to avoid visual clutter
- **Help improvements**: `/help` now lists all new commands with descriptions
- **Model forced override**: `/model <name>` sets `forcedModel` to bypass automatic model selection

## Testing

- All 283 existing tests pass (`go test ./...`)
- Updated `model_selection_test.go` to match new `selectModelForQuery` signature
- `go fmt ./...` and `go vet ./...` clean

## Checklist

- [x] I have read the contributing guidelines
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated documentation as needed
- [x] I have run `go fmt ./...`
- [x] I have run `go vet ./...`
