### PR TITLE
docs: update website with latest features and commands

### DIFF
--- a/website/docs.md
+++ b/website/docs.md
@@ -153,7 +153,7 @@ You can switch modes during a session without restarting:
 All commands available at the `❯` prompt:
 
 | Command | Description |
-|---|---|
+| ------- | ----------- |
 | `/help` | Show all available commands |
 | `/clear`, `/new` | Start a fresh conversation |
 | `/usage` | Show session duration, turns, and quota |

--- a/website/docs.md
+++ b/website/docs.md
@@ -251,7 +251,7 @@ See the [Execution Modes documentation](https://github.com/e9169/kopilot/blob/ma
 
 ### 🎭 Specialist Agent Personas
 
-Kopilot ships four domain-focused AI personas that sharpen the assistant for specific operational areas. Start with `--agent <name>` or switch mid-session with `/agent <name>`.
+Kopilot ships five domain-focused AI personas that sharpen the assistant for specific operational areas. Start with `--agent <name>` or switch mid-session with `/agent <name>`.
 
 **🔍 Debugger** (`--agent debugger`)
 Root cause analysis, log correlation, and pod failure diagnosis. Starts with events and recent changes, correlates pod status and logs, traces failure chains.

--- a/website/docs.md
+++ b/website/docs.md
@@ -292,11 +292,17 @@ Kopilot supports connecting to external [Model Context Protocol (MCP)](https://m
 kopilot --mcp-config ~/.kopilot/mcp.json
 ```
 
-The config file is a JSON object mapping server names to their URLs:
+The config file is a JSON object with a `servers` array. Each server entry must include `name`, `type`, and `url`:
 
 ```json
 {
-  "my-server": "http://localhost:8080/mcp"
+  "servers": [
+    {
+      "name": "my-server",
+      "type": "http",
+      "url": "http://localhost:8080/mcp"
+    }
+  ]
 }
 ```
 

--- a/website/docs.md
+++ b/website/docs.md
@@ -179,7 +179,7 @@ All commands available at the `❯` prompt:
 **Shortcuts:**
 
 | Shortcut | Description |
-|---|---|
+| -------- | ----------- |
 | `@<filepath>` | Attach a file to the next message |
 | `!<command>` | Run a shell command without AI |
 | `Ctrl+C` | Cancel current input or abort AI response |

--- a/website/docs.md
+++ b/website/docs.md
@@ -90,6 +90,22 @@ Kopilot supports any model available in your GitHub Copilot plan, including: `gp
 
 No API key configuration needed - authentication is handled through GitHub Copilot CLI.
 
+### CLI Flags
+
+```text
+kopilot [flags]
+
+Flags:
+  --interactive       Enable interactive mode (prompts before write operations)
+  --agent <name>      Start with a specialist agent persona (default, debugger, security, optimizer, gitops, sanitizer)
+  --context <name>    Override the active kubeconfig context
+  --kubeconfig <path> Path to kubeconfig file (default: $KUBECONFIG or ~/.kube/config)
+  --output <format>   Output format: text (default) or json
+  --mcp-config <path> Path to MCP server config file (default: ~/.kopilot/mcp.json)
+  --version           Print version information
+  -v, --verbose       Enable verbose logging
+```
+
 ---
 
 ## Basic Usage
@@ -129,8 +145,45 @@ You can switch modes during a session without restarting:
 ```text
 ❯ /readonly          # Switch to read-only mode
 ❯ /interactive       # Switch to interactive mode
-❯ /mode             # Show current mode
+❯ /mode              # Show current mode
 ```
+
+### Runtime Command Reference
+
+All commands available at the `❯` prompt:
+
+| Command | Description |
+|---|---|
+| `/help` | Show all available commands |
+| `/clear`, `/new` | Start a fresh conversation |
+| `/usage` | Show session duration, turns, and quota |
+| `/compact` | Summarize history to save context window |
+| `/last` | Re-show the last full response |
+| `/copy` | Copy the last response to clipboard |
+| `/mode`, `/status` | Show current execution mode |
+| `/readonly` | Switch to read-only mode |
+| `/interactive` | Switch to interactive mode |
+| `/model` | Show current model or routing mode |
+| `/model <name>` | Force a specific model for this session |
+| `/model reset` | Re-enable automatic model routing |
+| `/streamer [on\|off]` | Hide quota badge (useful for screen-sharing) |
+| `/context list` | List all kubeconfig contexts |
+| `/context use <name>` | Switch active context |
+| `/agent` | Show active agent and available roster |
+| `/agent list` | Same as `/agent` |
+| `/agent <name>` | Switch specialist agent |
+| `/mcp list` | List configured MCP servers |
+| `/mcp add <name> <url>` | Add or update an MCP server |
+| `/mcp delete <name>` | Remove an MCP server |
+
+**Shortcuts:**
+
+| Shortcut | Description |
+|---|---|
+| `@<filepath>` | Attach a file to the next message |
+| `!<command>` | Run a shell command without AI |
+| `Ctrl+C` | Cancel current input or abort AI response |
+| `Ctrl+D` | Exit Kopilot |
 
 ### Example Session
 
@@ -194,15 +247,6 @@ Kopilot provides two safety modes:
 - Requires explicit approval (yes/no)
 - Can be started with `--interactive` flag or switched at runtime with `/interactive`
 
-#### Runtime Commands
-
-- `/help` - Show all available commands
-- `/readonly` - Switch to read-only mode
-- `/interactive` - Switch to interactive mode
-- `/mode` - Show current execution mode
-- `/agent` or `/agent list` - Show active agent and roster
-- `/agent <name>` - Switch specialist agent
-
 See the [Execution Modes documentation](https://github.com/e9169/kopilot/blob/main/docs/EXECUTION_MODES.md) for detailed information
 
 ### 🎭 Specialist Agent Personas
@@ -229,9 +273,58 @@ Flux and ArgoCD sync status, drift detection, and reconciliation diagnostics. Al
 
 - *Try: "Are all Flux Kustomizations synced?" / "Find resources modified outside of GitOps"*
 
+**🧹 Sanitizer** (`--agent sanitizer`)
+Workload linting, best-practice scoring, and cluster health grading. Scores workloads against rules covering probes, resource limits, image tags, replica counts, and container hygiene. Produces an A–F grade with prioritised remediation steps.
+
+- *Try: "Sanitize my cluster and give me a grade" / "Which workloads are missing health probes?"*
+
 All specialist agents always use the premium model for the best reasoning quality. Agents and execution modes are independent — read-only protection is always enforced regardless of active agent.
 
 See the [Agents documentation](https://github.com/e9169/kopilot/blob/main/docs/AGENTS.md) for full details.
+
+### 🔌 MCP Servers
+
+Kopilot supports connecting to external [Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers, allowing it to call tools from any MCP-compatible service.
+
+**Configure at startup:**
+
+```bash
+kopilot --mcp-config ~/.kopilot/mcp.json
+```
+
+The config file is a JSON object mapping server names to their URLs:
+
+```json
+{
+  "my-server": "http://localhost:8080/mcp"
+}
+```
+
+**Manage servers at runtime:**
+
+```text
+❯ /mcp list                          # list configured servers
+❯ /mcp add my-server http://host/mcp # add or update a server
+❯ /mcp delete my-server              # remove a server
+```
+
+Changes take effect immediately — no restart required.
+
+### 📎 File Attachments and Shell Shortcuts
+
+Attach files directly to a message using the `@` prefix:
+
+```text
+❯ @deployment.yaml what's wrong with this deployment?
+❯ @logs.txt summarize these error logs
+```
+
+Run shell commands without involving AI using `!`:
+
+```text
+❯ !kubectl get pods -A
+❯ !helm list
+```
 
 ### 🔐 Security
 

--- a/website/index.md
+++ b/website/index.md
@@ -102,7 +102,7 @@ kopilot
   <div style="padding: 1.5rem; border: 2px solid transparent; background: linear-gradient(#0a1628, #0a1628) padding-box, linear-gradient(135deg, #06b6d4, #8b5cf6) border-box; border-radius: 0.5rem;">
     <div style="font-size: 3rem; margin-bottom: 0.5rem;">🎭</div>
     <h3 style="background: linear-gradient(135deg, #06b6d4, #8b5cf6); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">Specialist Agents</h3>
-    <p>Four domain-focused AI personas: <strong>Debugger</strong> 🔍 for root cause analysis, <strong>Security</strong> 🛡️ for RBAC &amp; privilege audits, <strong>Optimizer</strong> ⚡ for resource right-sizing, and <strong>GitOps</strong> 🔄 for Flux/ArgoCD sync. Switch at runtime with <code>/agent &lt;name&gt;</code>.</p>
+    <p>Five domain-focused AI personas: <strong>Debugger</strong> 🔍 for root cause analysis, <strong>Security</strong> 🛡️ for RBAC &amp; privilege audits, <strong>Optimizer</strong> ⚡ for resource right-sizing, <strong>GitOps</strong> 🔄 for Flux/ArgoCD sync, and <strong>Sanitizer</strong> 🧹 for best-practice scoring and cluster grading. Switch at runtime with <code>/agent &lt;name&gt;</code>.</p>
   </div>
   
   <div style="padding: 1.5rem; border: 2px solid transparent; background: linear-gradient(#0a1628, #0a1628) padding-box, linear-gradient(135deg, #06b6d4, #ec4899) border-box; border-radius: 0.5rem;">
@@ -121,6 +121,18 @@ kopilot
     <div style="font-size: 3rem; margin-bottom: 0.5rem;">💡</div>
     <h3 style="background: linear-gradient(135deg, #8b5cf6, #a78bfa); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">Smart Suggestions</h3>
     <p>3 random example prompts shown on each launch to help you discover capabilities and get started quickly.</p>
+  </div>
+
+  <div style="padding: 1.5rem; border: 2px solid transparent; background: linear-gradient(#0a1628, #0a1628) padding-box, linear-gradient(135deg, #06b6d4, #14b8a6) border-box; border-radius: 0.5rem;">
+    <div style="font-size: 3rem; margin-bottom: 0.5rem;">🔌</div>
+    <h3 style="background: linear-gradient(135deg, #06b6d4, #22d3ee); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">MCP Servers</h3>
+    <p>Connect to any <a href="https://modelcontextprotocol.io" style="color: #06b6d4;">Model Context Protocol</a> server to extend Kopilot with custom tools. Add, remove, and list servers at runtime with <code>/mcp</code>.</p>
+  </div>
+
+  <div style="padding: 1.5rem; border: 2px solid transparent; background: linear-gradient(#0a1628, #0a1628) padding-box, linear-gradient(135deg, #8b5cf6, #ec4899) border-box; border-radius: 0.5rem;">
+    <div style="font-size: 3rem; margin-bottom: 0.5rem;">📎</div>
+    <h3 style="background: linear-gradient(135deg, #8b5cf6, #a78bfa); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">File Attachments &amp; Shell</h3>
+    <p>Attach local files to your message with <code>@&lt;file&gt;</code> for AI analysis, or run shell commands directly with <code>!&lt;command&gt;</code> — no context switching needed.</p>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
Update the website (docs.md and index.md) and README.md to reflect all features and commands available in the current codebase that were missing or outdated.

**Changes to docs.md:**
- Add CLI flags reference section (all `--flag` options)
- Replace minimal runtime command list with a full reference table (20+ commands including `/compact`, `/copy`, `/last`, `/usage`, `/streamer`, `/model`, `/context`, `/mcp`)
- Add shortcuts table (`@<file>` attachments, `!<cmd>` shell passthrough, Ctrl+C/D)
- Add Sanitizer as the 5th specialist agent persona
- Add MCP Servers section with config file format and runtime commands
- Add File Attachments and Shell Shortcuts section with examples
- Fix `/usage` showing 'unlimited' before first turn (shows 'not yet available' instead)
- Fix broken emoji characters in section headers

**Changes to index.md:**
- Update Specialist Agents feature card from four to five agents, adding Sanitizer
- Add MCP Servers feature card
- Add File Attachments & Shell feature card

**Changes to README.md:**
- Add sanitizer as the 5th specialist agent persona to features list, usage examples, runtime commands, `--agent` flag, and personas table
- Add `--mcp-config` flag to Command-Line Flags section
- Add Runtime Context Switching section (`/context list`, `/context use`)
- Add MCP Servers section (`/mcp list/add/delete`)
- Add Model Selection section (`/model`, `/model <name>`, `/model reset`)
- Add Session Management commands (`/compact`, `/usage`, `/last`, `/copy`, `/clear`, `/streamer`)
- Add Shortcuts table (`@<file>` attachments, `!<cmd>` shell passthrough, Ctrl+C/D)

## Checklist
- [x] Documentation only (no code changes)
