### PR TITLE
fix: replace unavailable gpt-4.1 default with gpt-5.4-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ An interactive agent built with the **official GitHub Copilot SDK** in Go that p
 - 📄 **Plain-Text Output**: Responses use emoji + uppercase headers (e.g. `🔵 STATUS:`, `⚠️ ISSUES:`) for clean, readable output without markdown tables or bold formatting
 - 🎯 **Type-Safe Tools**: Uses Copilot SDK's DefineTool for automatic schema generation
 - 💰 **Smart Cost Optimization**: Intelligent model selection based on task complexity (see [docs/MODEL_SELECTION.md](docs/MODEL_SELECTION.md))
-  - Uses `gpt-4.1` for simple queries (list, status, health checks)
+  - Uses `gpt-5.4-mini` for simple queries (list, status, health checks)
   - Automatically upgrades to `claude-sonnet-4.6` for troubleshooting and complex operations
   - 50-70% cost reduction while maintaining quality for critical tasks
 - 🎭 **Specialist Agent Personas**: Five focused AI personas for advanced operations (see [docs/AGENTS.md](docs/AGENTS.md))
@@ -345,7 +345,7 @@ KUBECONFIG=/path/to/kubeconfig ./bin/kopilot
 
 **Optional - Model Configuration:**
 
-- `KOPILOT_MODEL_COST_EFFECTIVE` - Override AI model for simple queries (default: `gpt-4.1`)
+- `KOPILOT_MODEL_COST_EFFECTIVE` - Override AI model for simple queries (default: `gpt-5.4-mini`)
 - `KOPILOT_MODEL_PREMIUM` - Override AI model for complex operations (default: `claude-sonnet-4.6`)
 
 **Optional - Execution:**

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -166,7 +166,7 @@ kopilot --help
 
 All specialist agents (`debugger`, `security`, `optimizer`, `gitops`) always use the **premium model** (`claude-sonnet-4.6` by default), regardless of how simple the query appears. This is because specialist reasoning benefits from higher model capacity — even a simple "list all pods" query issued through the Debugger agent may require deep context to give a meaningful diagnosis.
 
-The `default` agent uses intelligent model selection: cost-effective (`gpt-4.1`) for simple queries and premium for troubleshooting and complex operations. See [MODEL_SELECTION.md](MODEL_SELECTION.md) for details.
+The `default` agent uses intelligent model selection: cost-effective (`gpt-5.4-mini`) for simple queries and premium for troubleshooting and complex operations. See [MODEL_SELECTION.md](MODEL_SELECTION.md) for details.
 
 | Agent | Model strategy |
 | ------- | --------------- |

--- a/docs/MODEL_SELECTION.md
+++ b/docs/MODEL_SELECTION.md
@@ -6,7 +6,7 @@ Kopilot now uses intelligent model selection to optimize costs while maintaining
 
 ## Model Strategy
 
-### Cost-Effective Model: `gpt-4.1`
+### Cost-Effective Model: `gpt-5.4-mini`
 
 **Use Cases:**
 
@@ -47,7 +47,7 @@ Kopilot now uses intelligent model selection to optimize costs while maintaining
 
 The model selection is dynamic and happens automatically:
 
-1. **Initial Session**: Starts with `gpt-4.1` for health checks
+1. **Initial Session**: Starts with `gpt-5.4-mini` for health checks
 2. **Agent Check**: If a specialist agent is active (`debugger`, `security`, `optimizer`, `gitops`), always use the premium model regardless of query text
 3. **Query Analysis**: For the `default` agent, each user query is analyzed for complexity
 4. **Session Recreation**: When a different model is needed, the session is recreated with the optimal model
@@ -118,7 +118,7 @@ By using this strategy:
 Model switches are logged:
 
 ```text
-2024/01/15 10:30:45 Switching from gpt-4.1 to claude-sonnet-4.6 for query complexity
+2024/01/15 10:30:45 Switching from gpt-5.4-mini to claude-sonnet-4.6 for query complexity
 2024/01/15 10:30:45 Session created with model: claude-sonnet-4.6
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This directory contains technical documentation for developers and contributors.
 - **[AGENTS.md](AGENTS.md)** - Specialist agent personas (Debugger, Security, Optimizer, GitOps) — how to use them and what each one does
 - **[EXECUTION_MODES.md](EXECUTION_MODES.md)** - Execution mode system (read-only vs interactive) for safe kubectl operations
 - **[TESTING.md](TESTING.md)** - Comprehensive testing guide including test structure, coverage reports, and how to run tests
-- **[MODEL_SELECTION.md](MODEL_SELECTION.md)** - Intelligent model selection strategy for cost optimization (gpt-4.1 vs claude-sonnet-4.6)
+- **[MODEL_SELECTION.md](MODEL_SELECTION.md)** - Intelligent model selection strategy for cost optimization (gpt-5.4-mini vs claude-sonnet-4.6)
 - **[PERFORMANCE.md](PERFORMANCE.md)** - Performance optimization details, including parallel cluster checking implementation
 - **[INTERACTIVE_FEATURES.md](INTERACTIVE_FEATURES.md)** - Interactive and proactive features implementation, including kubectl command execution
 - **[VERSION_MANAGEMENT.md](VERSION_MANAGEMENT.md)** - Versioning strategy and release workflow using Git tags

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -407,7 +407,7 @@ func ParseAgentType(s string) (AgentType, error) {
 
 const (
 	// Default model selection constants
-	defaultModelCostEffective = "gpt-4.1"           // Cost-effective model for simple queries
+	defaultModelCostEffective = "gpt-5.4-mini"      // Cost-effective model for simple queries
 	defaultModelPremium       = "claude-sonnet-4.6" // Premium model for complex tasks
 
 	// ANSI color codes

--- a/pkg/agent/model_selection_test.go
+++ b/pkg/agent/model_selection_test.go
@@ -89,8 +89,8 @@ func TestSpecialistAgentsAlwaysUsePremiumModel(t *testing.T) {
 
 func TestModelConstants(t *testing.T) {
 	// Verify the constants have expected values
-	if modelCostEffective != "gpt-4.1" {
-		t.Errorf("modelCostEffective = %q, want %q", modelCostEffective, "gpt-4.1")
+	if modelCostEffective != "gpt-5.4-mini" {
+		t.Errorf("modelCostEffective = %q, want %q", modelCostEffective, "gpt-5.4-mini")
 	}
 
 	if modelPremium != "claude-sonnet-4.6" {

--- a/website/docs.md
+++ b/website/docs.md
@@ -70,7 +70,7 @@ Kopilot works with **any model available through your GitHub Copilot subscriptio
 
 **Default configuration:**
 
-- **Cost-effective model** (default: gpt-4.1) - Used for simple queries and status checks
+- **Cost-effective model** (default: gpt-5.4-mini) - Used for simple queries and status checks
 - **Premium model** (default: claude-sonnet-4.6) - Automatically selected for troubleshooting and complex operations
 
 **Customization:**
@@ -86,7 +86,7 @@ export KOPILOT_MODEL_PREMIUM="o1-preview"
 ./bin/kopilot
 ```
 
-Kopilot supports any model available in your GitHub Copilot plan, including: `gpt-4.1`, `claude-sonnet-4.6`, `claude-haiku-4.5`, `gpt-5-mini`, and others.
+Kopilot supports any model available in your GitHub Copilot plan, including: `gpt-5.4-mini`, `claude-sonnet-4.6`, `claude-haiku-4.5`, `gpt-5-mini`, and others.
 
 No API key configuration needed - authentication is handled through GitHub Copilot CLI.
 
@@ -347,7 +347,7 @@ Run shell commands without involving AI using `!`:
 
 Kopilot automatically selects the optimal model based on your query:
 
-- **Simple queries** (list, status, health) → Cost-effective model (default: gpt-4.1)
+- **Simple queries** (list, status, health) → Cost-effective model (default: gpt-5.4-mini)
 - **Complex operations** (troubleshooting, scaling, debugging) → Premium model (default: claude-sonnet-4.6)
 
 This provides 50-70% cost reduction while maintaining quality for critical tasks. You can customize which models are used via environment variables.


### PR DESCRIPTION
## Problem

kopilot fails at startup with:

```
Error: failed to run agent: failed to create session: failed to create copilot session: failed to create session: JSON-RPC Error -32603: Request session.create failed with message: Model "gpt-4.1" is not available.
```

The bundled Copilot CLI (1.0.65) dropped `gpt-4.1` from its model catalog, but kopilot's cost-effective default was still hardcoded to `gpt-4.1`. Since the initial session is created with the cost-effective model, startup fails immediately. The premium default `claude-sonnet-4.6` is still valid.

Current catalog: GPT-5.4, GPT-5.3-Codex, GPT-5.4 mini, GPT-5 mini, Claude Sonnet 4.6/4.5, Claude Haiku 4.5, Gemini 3.1 Pro, Gemini 3.5 Flash, MAI-Code-1-Flash.

## Changes

- `pkg/agent/agent.go` — default cost-effective model `gpt-4.1` → `gpt-5.4-mini` (verified it creates a session)
- `pkg/agent/model_selection_test.go` — updated the constant assertion
- Docs (`README.md`, `docs/MODEL_SELECTION.md`, `docs/AGENTS.md`, `docs/README.md`, `website/docs.md`) — replaced stale `gpt-4.1` references

## Verification

- `go test ./pkg/agent/` passes
- Fresh build starts cleanly: `Session created with model: gpt-5.4-mini, agent: default`

The model catalog is account/CLI-version dependent; runtime overrides remain available via `KOPILOT_MODEL_COST_EFFECTIVE` / `KOPILOT_MODEL_PREMIUM`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)